### PR TITLE
refactor: replace Q_ASSERT(false) with Q_UNREACHABLE() to fix warnings

### DIFF
--- a/include/qml_material/scenegraph/skia_shadow.h
+++ b/include/qml_material/scenegraph/skia_shadow.h
@@ -240,7 +240,7 @@ public:
         case kStroke_RRectType: return kVertsPerStrokeRRect;
         case kOverstroke_RRectType: return kVertsPerOverstrokeRRect;
         }
-        Q_ASSERT(false);
+        Q_UNREACHABLE();
     }
 
     static int rrect_type_to_index_count(RRectType type) {
@@ -249,7 +249,7 @@ public:
         case kStroke_RRectType: return kIndicesPerStrokeRRect;
         case kOverstroke_RRectType: return kIndicesPerOverstrokeRRect;
         }
-        Q_ASSERT(false);
+        Q_UNREACHABLE();
     }
 
     static const uint16_t* rrect_type_to_indices(RRectType type) {
@@ -258,7 +258,7 @@ public:
         case kStroke_RRectType: return gRRectIndices + 6 * 4;
         case kOverstroke_RRectType: return gRRectIndices;
         }
-        Q_ASSERT(false);
+        Q_UNREACHABLE();
     }
 
 public:


### PR DESCRIPTION
```
/build/qcm-git/src/Qcm/qml_material/include/qml_material/scenegraph/skia_shadow.h: In static member function ‘static int qml_material::sk::ShadowCircularRRectOp::rrect_type_to_vert_count(RRectType)’:
/build/qcm-git/src/Qcm/qml_material/include/qml_material/scenegraph/skia_shadow.h:244:5: warning: control reaches end of non-void function [-Wreturn-type]
  244 |     }
      |     ^
/build/qcm-git/src/Qcm/qml_material/include/qml_material/scenegraph/skia_shadow.h: In static member function ‘static int qml_material::sk::ShadowCircularRRectOp::rrect_type_to_index_count(RRectType)’:
/build/qcm-git/src/Qcm/qml_material/include/qml_material/scenegraph/skia_shadow.h:253:5: warning: control reaches end of non-void function [-Wreturn-type]
  253 |     }
      |     ^
/build/qcm-git/src/Qcm/qml_material/include/qml_material/scenegraph/skia_shadow.h: In static member function ‘static const uint16_t* qml_material::sk::ShadowCircularRRectOp::rrect_type_to_indices(RRectType)’:
/build/qcm-git/src/Qcm/qml_material/include/qml_material/scenegraph/skia_shadow.h:262:5: warning: control reaches end of non-void function [-Wreturn-type]
  262 |     }
      |     ^
```