### PR TITLE
Add neutal palette

### DIFF
--- a/example/Color.qml
+++ b/example/Color.qml
@@ -72,6 +72,10 @@ MD.Page {
             ColorGroup {
                 model: ['outline', 'shadow', 'inverse_surface', 'inverse_on_surface', 'inverse_primary']
             }
+            ColorGroup {
+                model: ['neutral_10', 'neutral_20', 'neutral_30', 'neutral_40', 'neutral_50',
+                        'neutral_60', 'neutral_70', 'neutral_80', 'neutral_90', ]
+            }
         }
     }
 }

--- a/include/qml_material/helper.hpp
+++ b/include/qml_material/helper.hpp
@@ -5,6 +5,8 @@
 
 #include "qml_material/enum.hpp"
 
+#include "cpp/palettes/tones.h"
+
 namespace qml_material
 {
 struct MdScheme {
@@ -53,6 +55,8 @@ struct MdScheme {
     QRgb surface_container_lowest;
     QRgb surface_container_high;
     QRgb surface_container_highest;
+
+    material_color_utilities::TonalPalette neutral_palette { 0 };
 };
 
 auto MaterialLightColorScheme(QRgb, Enum::PaletteType) -> MdScheme;

--- a/include/qml_material/token/color.hpp
+++ b/include/qml_material/token/color.hpp
@@ -153,6 +153,27 @@ public:
     X(surface_container_highest)
 #undef X
 
+#define X(_n_)                                           \
+    Q_INVOKABLE QColor get_##_n_(double tone) const { return m_scheme._n_##_palette.get(tone); }
+
+    X(neutral)
+#undef X
+
+#define X(_n_, _tone_)                                   \
+    Q_PROPERTY(QColor _n_##_##_tone_ READ _n_##_##_tone_ NOTIFY schemeChanged) \
+        QColor _n_##_##_tone_() const { return m_scheme._n_##_palette.get(_tone_); }
+
+    X(neutral, 10)
+    X(neutral, 20)
+    X(neutral, 30)
+    X(neutral, 40)
+    X(neutral, 50)
+    X(neutral, 60)
+    X(neutral, 70)
+    X(neutral, 80)
+    X(neutral, 90)
+#undef X
+
 public:
     auto mode() const -> Enum::ThemeMode;
     auto sysColorScheme() const -> Enum::ThemeMode;

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -74,6 +74,8 @@ void convert_from(MdScheme& out, const md::DynamicScheme& in) {
     out.surface_3 = blend(out.surface, out.primary, 0.11);
     out.surface_4 = blend(out.surface, out.primary, 0.12);
     out.surface_5 = blend(out.surface, out.primary, 0.14);
+
+    out.neutral_palette = in.neutral_palette;
 }
 
 auto genScheme(qml_material::Enum::PaletteType t, Hct hct, bool is_dark, double ct_level) {


### PR DESCRIPTION
It adds neutral palette to QML. So, an user can use method `get_neutral` or use properties (for example `neutral_40`).
It can be used for other palettes.