### PR TITLE
Disable LTO for WIN32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ message("QML_INSTALL_DIR: ${QML_INSTALL_DIR}")
 # check lto
 include(CheckIPOSupported)
 check_ipo_supported(RESULT is_ipo_supported OUTPUT lto_error)
-if(is_ipo_supported AND NOT EMSCRIPTEN)
+if(is_ipo_supported AND NOT EMSCRIPTEN AND NOT WIN32)
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF)
 endif()


### PR DESCRIPTION
WARNING! I tried to enable lto for my Win project, but I got error:
```
E:/Qt/Tools/mingw1310_64/bin/../lib/gcc/x86_64-w64-mingw32/13.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/qsing-box.dir/qsing-box_qmltyperegistrations.cpp.obj: plugin needed to handle lto object
lto-wrapper.exe: warning: using serial compilation of 4 LTRANS jobs
lto-wrapper.exe: note: see the '-flto' option documentation for more information
E:/Qt/Tools/mingw1310_64/bin/../lib/gcc/x86_64-w64-mingw32/13.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\dimam\AppData\Local\Temp\ccgxcZHT.ltrans1.ltrans.o:<artificial>:(.rdata$.refptr._Z31qml_register_types_Qcm_Materialv[.refptr._Z31qml_register_types_Qcm_Materialv]+0x0): undefined reference to `qml_register_types_Qcm_Material()'
collect2.exe: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```
Maybe it is my mistake