### PR TITLE
{Label, Text}: Remove maximumLineCount

### DIFF
--- a/qml/component/Text.qml
+++ b/qml/component/Text.qml
@@ -17,6 +17,5 @@ Text {
     lineHeightMode: Text.FixedHeight
     wrapMode: Text.Wrap
     elide: Text.ElideRight
-    maximumLineCount: 1
     textFormat: Text.PlainText
 }

--- a/qml/control/Label.qml
+++ b/qml/control/Label.qml
@@ -26,6 +26,5 @@ T.Label {
     lineHeightMode: Text.FixedHeight
     wrapMode: Text.Wrap
     elide: Text.ElideRight
-    maximumLineCount: 1
     textFormat: Text.PlainText
 }


### PR DESCRIPTION
It is unexpected. So, real expectation is the property is not setted. Like in [documentation](https://doc.qt.io/qt-6/qml-qtquick-text.html#maximumLineCount-prop)