### PR TITLE
build: Search for private modules with Qt 6.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,11 @@ if(UNIX AND NOT APPLE)
 endif()
 
 find_package(Qt6 REQUIRED COMPONENTS Core Quick QuickControls2 Gui ShaderTools)
+
+if(Qt6Quick_VERSION VERSION_GREATER_EQUAL 6.10)
+  find_package(Qt6 REQUIRED COMPONENTS QuickPrivate)
+endif()
+
 find_package(PkgConfig REQUIRED)
 if(QT_KNOWN_POLICY_QTP0004)
   qt_policy(SET QTP0004 NEW)


### PR DESCRIPTION
According to [What's New in Qt 6.10](https://doc.qt.io/qt-6/whatsnew610.html#build-system-changes):

> Usage of a private Qt module Foo now requires a call to `find_package(Qt6 COMPONENTS FooPrivate)` to make the `Qt6::FooPrivate` target available.