### PR TITLE
fix: include the missing header file QElapsedTimer

### DIFF
--- a/src/kirigami/toolbarlayout.cpp
+++ b/src/kirigami/toolbarlayout.cpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 
 #include <QDeadlineTimer>
+#include <QElapsedTimer>
 #include <QQmlComponent>
 #include <QTimer>
 


### PR DESCRIPTION
The header file `QElapsedTimer` is required to build with Qt 6.10.