### PR TITLE
fix ColorRadio.qml display

### DIFF
--- a/example/Example.qml
+++ b/example/Example.qml
@@ -140,7 +140,7 @@ MD.Page {
                                         T.ActionGroup.group: m_palette_group
                                         icon.name: ''
                                         checkable: true
-                                        checked: m_palette_view.currentIndex == index
+                                        checked: m_palette_view.currentIndex === index
                                         onTriggered: function (c) {
                                             m_palette_view.currentIndex = index;
                                             MD.Token.color.paletteType = index;
@@ -172,7 +172,7 @@ MD.Page {
                                     MD.ColorRadio {
                                         size: 28
                                         color: modelData.color
-                                        checked: MD.Token.color.accentColor == color
+                                        checked: MD.Token.color.accentColor === color
                                         onClicked: {
                                             MD.Token.color.accentColor = color;
                                         }

--- a/qml/component/extra/ColorRadio.qml
+++ b/qml/component/extra/ColorRadio.qml
@@ -23,12 +23,13 @@ Item {
         Rectangle {
             anchors.centerIn: parent
             border.color: root.MD.MProp.color.surface
-            border.width: 0.25 * 0.5 * root.size
+            border.width: Math.max(1.2, width * 0.2)
             color: parent.color
+            width: parent.width
             height: width
             radius: width / 2
+            scale: root.checked ? 0.8 : 0.0
             visible: root.checked
-            width: root.size - 2 * border.width
         }
         MouseArea {
             anchors.fill: parent


### PR DESCRIPTION
Fixed the 1px (top-left) offset of the inner circle in ColorRadio by switching to scaling (scale: 0.8) instead of manually calculating the width, which eliminated subpixel rendering artifacts in QML.

Before:
![Uploading Screenshot from 2026-05-08 14-24-50.png…]()

---
After:
![Uploading Screenshot from 2026-05-08 15-53-45.png…]()
