### PR TITLE
Fix disabled SplitButton state

### DIFF
--- a/example/Components.qml
+++ b/example/Components.qml
@@ -238,6 +238,20 @@ MD.Page {
                                     }
                                 }
                             }
+                            MD.SplitButton {
+                                text: 'Disabled'
+                                mdState.type: MD.Enum.BtFilled
+                                enabled:false
+                                menu: MD.Menu {
+                                    MD.MenuItem {
+                                        text: 'Action 1'
+                                    }
+                                    MD.MenuItem {
+                                        text: 'Action 2'
+                                    }
+                                }
+                            }
+
                         }
                     }
 

--- a/qml/component/button/SplitButton.qml
+++ b/qml/component/button/SplitButton.qml
@@ -28,6 +28,7 @@ T.Control {
 
     implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset, implicitContentWidth + leftPadding + rightPadding)
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset, implicitContentHeight + topPadding + bottomPadding)
+    hoverEnabled: control.enabled
 
     spacing: 2
 
@@ -49,6 +50,7 @@ T.Control {
             mdState: control.indicatorMdState
             anchors.verticalCenter: parent.verticalCenter
             anchors.right: parent.right
+            enabled: control.enabled
         }
     }
 }

--- a/qml/component/button/SplitButtonIndicator.qml
+++ b/qml/component/button/SplitButtonIndicator.qml
@@ -22,6 +22,7 @@ T.Button {
     icon.name: checked ? MD.Token.icon.expand_less : MD.Token.icon.expand_more
 
     onClicked: {
+        if (!control.enabled) return;
         if (control.menu) {
             if (control.menu.visible) {
                 control.menu.close();
@@ -50,14 +51,14 @@ T.Button {
         size: control.icon.width
         color: control.mdState.textColor
         anchors.centerIn: parent
-        opacity: control.mdState.contentOpacity
+         opacity: control.mdState.contentOpacity
     }
 
     background: MD.ElevationRectangle {
         corners: control.mdState.corners
         color: control.mdState.backgroundColor
         elevation: control.mdState.elevation
-        
+        opacity: control.mdState.backgroundOpacity
         MD.Ripple {
             anchors.fill: parent
             corners: parent.corners


### PR DESCRIPTION
Visual improvments for **disabled** SplitButton.qml
1. Fix opacity for SplitButtonIndicator.qml
2. Fix hover enabled for SplitButton.qml

Before:
<img width="467" height="120" alt="Screenshot from 2026-05-08 17-26-40" src="https://github.com/user-attachments/assets/b6a9ca60-7289-460c-ae8b-50a06acc1879" />

---
After:
<img width="467" height="120" alt="Screenshot from 2026-05-08 17-20-31" src="https://github.com/user-attachments/assets/b77af7a8-64d2-4b9b-b747-01306a487b86" />


