### PR TITLE
Implement M3 Slider component with enhanced features

### DIFF
--- a/example/Components.qml
+++ b/example/Components.qml
@@ -773,51 +773,6 @@ MD.Page {
                         }
                     }
                     ComponentCard {
-                        title: 'Sliders'
-                        RowLayout {
-                            Layout.fillWidth: true
-                            spacing: 24
-
-                            ColumnLayout {
-                                Layout.fillWidth: true
-                                MD.Slider {
-                                    Layout.alignment: Qt.AlignHCenter
-                                }
-                                MD.Slider {
-                                    Layout.alignment: Qt.AlignHCenter
-                                    snapMode: T.Slider.SnapAlways
-                                    from: 0
-                                    stepSize: 20
-                                    to: 100
-                                }
-                                MD.SliderM2 {
-                                    Layout.alignment: Qt.AlignHCenter
-                                }
-                                MD.SliderM2 {
-                                    Layout.alignment: Qt.AlignHCenter
-                                    snapMode: T.Slider.SnapAlways
-                                    from: 0
-                                    stepSize: 20
-                                    to: 100
-                                }
-                            }
-
-                            RowLayout {
-                                spacing: 24
-                                MD.Slider {
-                                    orientation: Qt.Vertical
-                                    snapMode: T.Slider.SnapAlways
-                                    from: 0
-                                    stepSize: 20
-                                    to: 100
-                                }
-                                MD.SliderM2 {
-                                    orientation: Qt.Vertical
-                                }
-                            }
-                        }
-                    }
-                    ComponentCard {
                         title: 'Switches'
                         MD.Switch {
                             Layout.alignment: Qt.AlignHCenter
@@ -1086,6 +1041,265 @@ MD.Page {
                                     icon.name: MD.Token.icon.more_vert
                                 }
                             ]
+                        }
+                    }
+                }
+            }
+
+            MD.Pane {
+                Layout.alignment: Qt.AlignHCenter
+                ColumnLayout {
+                    spacing: 16
+                    MD.Text {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: 'Sliders'
+                        typescale: MD.Token.typescale.title_large
+                    }
+
+                    ComponentCard {
+                        title: 'M3'
+                        spacing: 12
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 24
+
+                            ColumnLayout {
+                                Layout.fillWidth: true
+                                spacing: 8
+
+                                MD.Text {
+                                    text: 'Continuous'
+                                    typescale: MD.Token.typescale.label_medium
+                                    opacity: 0.8
+                                }
+                                MD.Slider {
+                                    Layout.fillWidth: true
+                                    from: 0
+                                    to: 100
+                                }
+
+                                MD.Text {
+                                    text: 'No value / stop indicators'
+                                    typescale: MD.Token.typescale.label_medium
+                                    opacity: 0.8
+                                }
+                                MD.Slider {
+                                    Layout.fillWidth: true
+                                    from: 0
+                                    to: 100
+                                    labelBehavior: MD.Enum.SliderLabelGone
+                                    tickVisibilityMode: MD.Enum.SliderTickNone
+                                }
+
+                                MD.Text {
+                                    text: 'Discrete snap, no indicators'
+                                    typescale: MD.Token.typescale.label_medium
+                                    opacity: 0.8
+                                }
+                                MD.Slider {
+                                    Layout.fillWidth: true
+                                    snapMode: T.Slider.SnapAlways
+                                    from: 0
+                                    stepSize: 20
+                                    to: 100
+                                    labelBehavior: MD.Enum.SliderLabelGone
+                                    tickVisibilityMode: MD.Enum.SliderTickNone
+                                }
+
+                                MD.Text {
+                                    text: 'Discrete + stops'
+                                    typescale: MD.Token.typescale.label_medium
+                                    opacity: 0.8
+                                }
+                                MD.Slider {
+                                    Layout.fillWidth: true
+                                    snapMode: T.Slider.SnapAlways
+                                    from: 0
+                                    stepSize: 20
+                                    to: 100
+                                }
+
+                                MD.Text {
+                                    text: 'Snap without stops'
+                                    typescale: MD.Token.typescale.label_medium
+                                    opacity: 0.8
+                                }
+                                MD.Slider {
+                                    Layout.fillWidth: true
+                                    snapMode: T.Slider.SnapAlways
+                                    from: 0
+                                    stepSize: 20
+                                    to: 100
+                                    tickVisibilityMode: MD.Enum.SliderTickNone
+                                }
+
+                                MD.Text {
+                                    text: 'Value label always'
+                                    typescale: MD.Token.typescale.label_medium
+                                    opacity: 0.8
+                                }
+                                MD.Slider {
+                                    Layout.fillWidth: true
+                                    from: 0
+                                    to: 100
+                                    value: 50
+                                    labelBehavior: MD.Enum.SliderLabelVisible
+                                }
+                                MD.Text {
+                                    text: 'Inset icon'
+                                    typescale: MD.Token.typescale.label_medium
+                                    opacity: 0.8
+                                }
+                                MD.Slider {
+                                    Layout.fillWidth: true
+                                    from: 0
+                                    to: 100
+                                    value: 50
+                                    sliderSize: MD.Enum.SliderSizeMedium
+                                    insetIcon: MD.Token.icon.volume_up
+                                    insetIconAtMin: MD.Token.icon.volume_off
+                                    labelBehavior: MD.Enum.SliderLabelGone
+                                    tickVisibilityMode: MD.Enum.SliderTickNone
+                                }
+                            }
+
+                            GridLayout {
+                                Layout.alignment: Qt.AlignTop
+                                columns: 2
+                                rowSpacing: 16
+                                columnSpacing: 24
+
+                                ColumnLayout {
+                                    spacing: 8
+
+                                    MD.Text {
+                                        text: 'Continuous'
+                                        typescale: MD.Token.typescale.label_medium
+                                        opacity: 0.8
+                                    }
+                                    MD.Slider {
+                                        Layout.alignment: Qt.AlignHCenter
+                                        Layout.preferredHeight: 160
+                                        orientation: Qt.Vertical
+                                        from: 0
+                                        to: 100
+                                    }
+                                }
+
+                                ColumnLayout {
+                                    spacing: 8
+
+                                    MD.Text {
+                                        text: 'Discrete + stops'
+                                        typescale: MD.Token.typescale.label_medium
+                                        opacity: 0.8
+                                    }
+                                    MD.Slider {
+                                        Layout.alignment: Qt.AlignHCenter
+                                        Layout.preferredHeight: 160
+                                        orientation: Qt.Vertical
+                                        snapMode: T.Slider.SnapAlways
+                                        from: 0
+                                        stepSize: 20
+                                        to: 100
+                                    }
+                                }
+
+                                ColumnLayout {
+                                    spacing: 8
+
+                                    MD.Text {
+                                        text: 'Snap without stops'
+                                        typescale: MD.Token.typescale.label_medium
+                                        opacity: 0.8
+                                    }
+                                    MD.Slider {
+                                        Layout.alignment: Qt.AlignHCenter
+                                        Layout.preferredHeight: 160
+                                        orientation: Qt.Vertical
+                                        snapMode: T.Slider.SnapAlways
+                                        from: 0
+                                        stepSize: 20
+                                        to: 100
+                                        tickVisibilityMode: MD.Enum.SliderTickNone
+                                    }
+                                }
+
+                                ColumnLayout {
+                                    spacing: 8
+
+                                    MD.Text {
+                                        text: 'Inset icon'
+                                        typescale: MD.Token.typescale.label_medium
+                                        opacity: 0.8
+                                    }
+                                    MD.Slider {
+                                        Layout.alignment: Qt.AlignHCenter
+                                        Layout.preferredHeight: 240
+                                        orientation: Qt.Vertical
+                                        from: 0
+                                        to: 100
+                                        value: 60
+                                        sliderSize: MD.Enum.SliderSizeMedium
+                                        insetIcon: MD.Token.icon.music_note
+                                        insetIconAtMin: MD.Token.icon.volume_off
+                                        labelBehavior: MD.Enum.SliderLabelGone
+                                        tickVisibilityMode: MD.Enum.SliderTickNone
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    ComponentCard {
+                        title: 'M2'
+                        spacing: 12
+
+                        RowLayout {
+                            Layout.alignment: Qt.AlignHCenter
+                            spacing: 24
+
+                            ColumnLayout {
+                                spacing: 8
+
+                                MD.Text {
+                                    text: 'Continuous'
+                                    typescale: MD.Token.typescale.label_medium
+                                    opacity: 0.8
+                                }
+                                MD.SliderM2 {
+                                    Layout.alignment: Qt.AlignHCenter
+                                }
+
+                                MD.Text {
+                                    text: 'Discrete'
+                                    typescale: MD.Token.typescale.label_medium
+                                    opacity: 0.8
+                                }
+                                MD.SliderM2 {
+                                    Layout.alignment: Qt.AlignHCenter
+                                    snapMode: T.Slider.SnapAlways
+                                    from: 0
+                                    stepSize: 20
+                                    to: 100
+                                }
+                            }
+
+                            ColumnLayout {
+                                spacing: 8
+
+                                MD.Text {
+                                    Layout.alignment: Qt.AlignHCenter
+                                    text: 'Vertical'
+                                    typescale: MD.Token.typescale.label_medium
+                                    opacity: 0.8
+                                }
+                                MD.SliderM2 {
+                                    Layout.alignment: Qt.AlignHCenter
+                                    orientation: Qt.Vertical
+                                }
+                            }
                         }
                     }
                 }

--- a/include/qml_material/core/enum.hpp
+++ b/include/qml_material/core/enum.hpp
@@ -196,6 +196,33 @@ public:
         CarouselSizeLarge,
     };
     Q_ENUM(CarouselSizeClass)
+
+    enum class SliderLabelBehavior
+    {
+        SliderLabelFloating = 0, ///< Show value indicator while interacting
+        SliderLabelVisible,      ///< Always show value indicator
+        SliderLabelGone,           ///< Never show value indicator
+        SliderLabelWithinBounds,   ///< Show within track bounds while interacting
+    };
+    Q_ENUM(SliderLabelBehavior)
+
+    enum class SliderTickVisibilityMode
+    {
+        SliderTickAutoLimit = 0, ///< Cap discrete stops; no caps on continuous
+        SliderTickAll,           ///< Show all stops (discrete) or end caps (continuous)
+        SliderTickNone,          ///< Hide all stop indicators
+    };
+    Q_ENUM(SliderTickVisibilityMode)
+
+    enum class SliderSize
+    {
+        SliderSizeXSmall = 0, ///< 16dp active track
+        SliderSizeSmall,      ///< 24dp
+        SliderSizeMedium,     ///< 40dp — minimum for inset icon
+        SliderSizeLarge,      ///< 56dp
+        SliderSizeXLarge,     ///< 96dp
+    };
+    Q_ENUM(SliderSize)
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS(Enum::ToastFlags);
 } // namespace qml_material

--- a/include/qml_material/token/token.hpp
+++ b/include/qml_material/token/token.hpp
@@ -440,6 +440,43 @@ public:
 };
 
 /**
+ * @brief Slider layout tokens (M3 Slider specs)
+ */
+struct Slider {
+    Q_GADGET
+    QML_ANONYMOUS
+    Q_PROPERTY(qreal active_track_height MEMBER active_track_height CONSTANT FINAL)
+    Q_PROPERTY(qreal inactive_track_height MEMBER inactive_track_height CONSTANT FINAL)
+    Q_PROPERTY(qreal active_track_height_xsmall MEMBER active_track_height_xsmall CONSTANT FINAL)
+    Q_PROPERTY(qreal active_track_height_small MEMBER active_track_height_small CONSTANT FINAL)
+    Q_PROPERTY(qreal active_track_height_medium MEMBER active_track_height_medium CONSTANT FINAL)
+    Q_PROPERTY(qreal active_track_height_large MEMBER active_track_height_large CONSTANT FINAL)
+    Q_PROPERTY(qreal active_track_height_xlarge MEMBER active_track_height_xlarge CONSTANT FINAL)
+    Q_PROPERTY(qreal stop_indicator_size MEMBER stop_indicator_size CONSTANT FINAL)
+    Q_PROPERTY(qreal thumb_track_gap MEMBER thumb_track_gap CONSTANT FINAL)
+    Q_PROPERTY(qreal track_inside_corner MEMBER track_inside_corner CONSTANT FINAL)
+    Q_PROPERTY(qreal inset_icon_size MEMBER inset_icon_size CONSTANT FINAL)
+    Q_PROPERTY(qreal inset_icon_padding MEMBER inset_icon_padding CONSTANT FINAL)
+    Q_PROPERTY(qint32 handle_height MEMBER handle_height CONSTANT FINAL)
+    Q_PROPERTY(qint32 handle_width MEMBER handle_width CONSTANT FINAL)
+public:
+    qreal active_track_height { 16 };
+    qreal inactive_track_height { 4 };
+    qreal active_track_height_xsmall { 16 };
+    qreal active_track_height_small { 24 };
+    qreal active_track_height_medium { 40 };
+    qreal active_track_height_large { 56 };
+    qreal active_track_height_xlarge { 96 };
+    qreal stop_indicator_size { 4 };
+    qreal thumb_track_gap { 6 };
+    qreal track_inside_corner { 2 };
+    qreal inset_icon_size { 24 };
+    qreal inset_icon_padding { 8 };
+    i32   handle_height { 44 };
+    i32   handle_width { 12 };
+};
+
+/**
  * @brief Defines standard spacing values
  *
  * Provides a set of consistent spacing values used for layout,
@@ -524,6 +561,7 @@ class Token : public QObject {
     Q_PROPERTY(qml_material::token::BadgeSize badge READ badge CONSTANT FINAL)
     /// Carousel layout tokens
     Q_PROPERTY(qml_material::token::Carousel carousel READ carousel CONSTANT FINAL)
+    Q_PROPERTY(qml_material::token::Slider slider READ slider CONSTANT FINAL)
     public:
     Token(QObject* = nullptr);
     ~Token();
@@ -549,6 +587,7 @@ class Token : public QObject {
     auto icon_button() const -> const IconButtonSize&;
     auto badge() const -> const BadgeSize&;
     auto carousel() const -> const Carousel&;
+    auto slider() const -> const Slider&;
 
     auto datas() -> QQmlListProperty<QObject>;
 
@@ -571,6 +610,7 @@ class Token : public QObject {
     IconButtonSize      m_icon_button;
     BadgeSize       m_badge;
     Carousel        m_carousel;
+    Slider          m_slider;
 
     QList<QObject*> m_datas;
     };

--- a/qml/control/Slider.qml
+++ b/qml/control/Slider.qml
@@ -17,6 +17,16 @@ T.Slider {
 
     rightPadding: __tailingReserve
 
+    property int labelBehavior: MD.Enum.SliderLabelFloating
+    property int tickVisibilityMode: MD.Enum.SliderTickAutoLimit
+    property int sliderSize: MD.Enum.SliderSizeXSmall
+
+    property string insetIcon: ''
+    property string insetIconAtMin: ''
+    property real insetIconSize: MD.Token.slider.inset_icon_size
+    property color insetIconActiveColor: control.mdState.textColor
+    property color insetIconInactiveColor: control.mdState.trackMarkInactiveColor
+
     implicitWidth: {
         const contentWidth = implicitBackgroundWidth + leftInset + rightInset;
         const handleContentWidth = implicitHandleWidth + leftPadding + rightPadding;
@@ -28,11 +38,8 @@ T.Slider {
         return Math.max(contentHeight, handleContentHeight);
     }
 
-    clip: false
-
     // Cursor handling
     PointHandler {
-        id: mouseHandler
         cursorShape: {
             if (control.pressed)
                 return Qt.ClosedHandCursor;
@@ -59,13 +66,54 @@ T.Slider {
     // collapse into a solid line. Snap behavior stays driven by
     // `stepSize`; this only affects how many decorative dots are drawn.
     property int maxVisibleStops: 20
+
+    readonly property bool __showStopIndicators: control.tickVisibilityMode !== MD.Enum.SliderTickNone
+    readonly property bool __showContinuousEndCaps: control.__showStopIndicators
+            && !control.__isDiscrete
+            && control.tickVisibilityMode === MD.Enum.SliderTickAll
+
     readonly property int __dotCount: {
-        if (!__isDiscrete)
+        if (!control.__isDiscrete || !control.__showStopIndicators)
             return 0;
-        const total = Math.floor(__steps);
-        return Math.min(total, maxVisibleStops) + 1;
+        const total = Math.floor(control.__steps);
+        if (control.tickVisibilityMode === MD.Enum.SliderTickAll)
+            return total + 1;
+        return Math.min(total, control.maxVisibleStops) + 1;
     }
-    readonly property real __dotStep: __dotCount > 1 ? 1.0 / (__dotCount - 1) : 0
+    readonly property real __dotStep: control.__dotCount > 1 ? 1.0 / (control.__dotCount - 1) : 0
+
+    readonly property real __trackGapSize: MD.Token.slider.thumb_track_gap + control.mdState.handleLineWidth / 2
+
+    readonly property real __activeTrackThickness: {
+        switch (control.sliderSize) {
+        case MD.Enum.SliderSizeSmall:
+            return MD.Token.slider.active_track_height_small;
+        case MD.Enum.SliderSizeMedium:
+            return MD.Token.slider.active_track_height_medium;
+        case MD.Enum.SliderSizeLarge:
+            return MD.Token.slider.active_track_height_large;
+        case MD.Enum.SliderSizeXLarge:
+            return MD.Token.slider.active_track_height_xlarge;
+        default:
+            return MD.Token.slider.active_track_height_xsmall;
+        }
+    }
+    readonly property real __inactiveTrackThickness:
+        control.sliderSize >= MD.Enum.SliderSizeMedium
+            ? control.__activeTrackThickness
+            : MD.Token.slider.inactive_track_height
+    readonly property real __stopSize: MD.Token.slider.stop_indicator_size
+    readonly property real __insideCorner: MD.Token.slider.track_inside_corner
+    readonly property real __outerCorner: control.__activeTrackThickness / 2
+
+    readonly property bool __hasInsetIcon: control.insetIcon.length > 0
+            && control.sliderSize >= MD.Enum.SliderSizeMedium
+
+    readonly property string __resolvedInsetIcon:
+        control.insetIconAtMin.length > 0 && control.value <= control.from + Number.EPSILON
+            ? control.insetIconAtMin
+            : control.insetIcon
+
     readonly property real handleCenter: {
         const trackLength = control.horizontal ? control.availableWidth : control.availableHeight;
         const handleSize = control.mdState.handleWidth;
@@ -73,7 +121,62 @@ T.Slider {
         return control.visualPosition * (trackLength - handleSize) + handleSize / 2 + paddingOffset;
     }
 
+    readonly property real __horizontalActiveTrackLength:
+        control.handleCenter - control.leftPadding - control.__trackGapSize
+
+    readonly property real __inactiveTopLength:
+        control.handleCenter - control.__trackGapSize - control.topPadding
+
+    readonly property real __insetIconDivider: control.handleCenter + control.__trackGapSize
+
+    readonly property real __insetIconPad: MD.Token.slider.inset_icon_padding
+
+    readonly property bool __insetIconOnActiveTrack:
+        control.horizontal
+            && control.__horizontalActiveTrackLength
+                    >= control.insetIconSize + 2 * control.__insetIconPad
+
+    readonly property bool __verticalInsetIconFitsAtTop:
+        control.__inactiveTopLength >= control.insetIconSize + 2 * control.__insetIconPad
+
+    readonly property real __insetIconX: {
+        if (control.horizontal) {
+            if (control.__insetIconOnActiveTrack) {
+                return control.leftPadding + control.__insetIconPad;
+            }
+            return control.handleCenter + control.__trackGapSize + control.__insetIconPad;
+        }
+        return (control.implicitBackgroundWidth - control.insetIconSize) / 2;
+    }
+
+    readonly property real __insetIconY: {
+        if (control.horizontal) {
+            return (control.implicitBackgroundHeight - control.insetIconSize) / 2;
+        }
+        if (control.__verticalInsetIconFitsAtTop) {
+            return control.__insetIconPad;
+        }
+        return control.handleCenter + control.__trackGapSize + control.__insetIconPad;
+    }
+
+    readonly property color __insetIconColor: {
+        if (control.horizontal) {
+            return control.__insetIconOnActiveTrack
+                    ? control.insetIconActiveColor
+                    : control.insetIconInactiveColor;
+        }
+        if (!control.__verticalInsetIconFitsAtTop) {
+            return control.insetIconActiveColor;
+        }
+        const iconCenterY = control.__insetIconPad + control.insetIconSize / 2;
+        return iconCenterY >= control.__insetIconDivider
+                ? control.insetIconActiveColor
+                : control.insetIconInactiveColor;
+    }
+
     handle: MD.SliderHandle {
+        // Above background so the separator line paints over active/inactive tracks.
+        z: 2
         x: {
             const availableSpace = control.availableWidth - width;
             const offset = control.horizontal ? control.visualPosition * availableSpace : availableSpace / 2;
@@ -85,6 +188,7 @@ T.Slider {
             return control.topPadding + offset;
         }
         value: control.value
+        labelBehavior: control.labelBehavior
         handleHasFocus: control.visualFocus
         handlePressed: control.pressed
         handleHovered: control.hovered
@@ -97,24 +201,26 @@ T.Slider {
     background: Item {
         id: bgItem
         opacity: control.mdState.backgroundOpacity
-        implicitWidth: control.horizontal ? 200 : 44
-        implicitHeight: control.horizontal ? 44 : 200
+        implicitWidth: control.horizontal
+            ? 200
+            : Math.max(control.mdState.handleHeight, control.__activeTrackThickness)
+        implicitHeight: control.horizontal
+            ? Math.max(control.mdState.handleHeight, control.__activeTrackThickness)
+            : 200
 
-        readonly property bool isHandleSmall: control.pressed || control.visualFocus
-        readonly property real gapSize: 6 + control.mdState.handleLineWidth / 2
+        readonly property real gapSize: control.__trackGapSize
 
-        // Inactive Track (Right for horizontal, Top for vertical)
+        // Inactive Track (right for horizontal, top for vertical)
         MD.Rectangle {
-            id: inactiveTrack
             x: {
                 if (control.horizontal) {
                     return control.handleCenter + bgItem.gapSize;
                 }
-                return (bgItem.width - 16) / 2;
+                return (bgItem.width - control.__inactiveTrackThickness) / 2;
             }
             y: {
                 if (control.horizontal) {
-                    return (bgItem.height - 16) / 2;
+                    return (bgItem.height - control.__inactiveTrackThickness) / 2;
                 }
                 return 0;
             }
@@ -123,36 +229,33 @@ T.Slider {
                     const trackEnd = bgItem.width - control.rightPadding;
                     return Math.max(0, trackEnd - x);
                 }
-                return 16;
+                return control.__inactiveTrackThickness;
             }
             height: {
                 if (control.horizontal) {
-                    return 16;
+                    return control.__inactiveTrackThickness;
                 }
                 return Math.max(0, control.handleCenter - bgItem.gapSize - y);
             }
             corners: {
-                if (control.horizontal) {
-                    return MD.Util.corners(2, 8, 2, 8);
-                }
-                return MD.Util.corners(8, 8, 2, 2);
+                const r = control.__inactiveTrackThickness / 2;
+                return MD.Util.corners(r, r, r, r);
             }
             color: control.mdState.trackInactiveColor
             visible: width > 0 && height > 0
         }
 
-        // Active Track (Left for horizontal, Bottom for vertical)
+        // Active Track (left for horizontal, bottom for vertical)
         MD.Rectangle {
-            id: activeTrack
             x: {
                 if (control.horizontal) {
                     return 0;
                 }
-                return (bgItem.width - 16) / 2;
+                return (bgItem.width - control.__activeTrackThickness) / 2;
             }
             y: {
                 if (control.horizontal) {
-                    return (bgItem.height - 16) / 2;
+                    return (bgItem.height - control.__activeTrackThickness) / 2;
                 }
                 return control.handleCenter + bgItem.gapSize;
             }
@@ -160,62 +263,109 @@ T.Slider {
                 if (control.horizontal) {
                     return Math.max(0, control.handleCenter - bgItem.gapSize - x);
                 }
-                return 16;
+                return control.__activeTrackThickness;
             }
             height: {
                 if (control.horizontal) {
-                    return 16;
+                    return control.__activeTrackThickness;
                 }
                 return Math.max(0, bgItem.height - y);
             }
             corners: {
                 if (control.horizontal) {
-                    return MD.Util.corners(8, 2, 8, 2);
+                    return MD.Util.corners(control.__outerCorner, control.__insideCorner,
+                                           control.__outerCorner, control.__insideCorner);
                 }
-                return MD.Util.corners(2, 2, 8, 8);
+                return MD.Util.corners(control.__insideCorner, control.__insideCorner,
+                                       control.__outerCorner, control.__outerCorner);
             }
             color: control.mdState.trackColor
             visible: width > 0 && height > 0
         }
-        // Stop Indicators
+
+        MD.Icon {
+            z: 1
+            visible: control.__hasInsetIcon
+            name: control.__resolvedInsetIcon
+            size: control.insetIconSize
+            color: control.__insetIconColor
+            x: control.__insetIconX
+            y: control.__insetIconY
+        }
+
+        // Stop indicator at track start (continuous + tickVisibilityMode All only)
         MD.Rectangle {
-            id: stopEnd
-            width: 4
-            height: 4
-            radius: 2
+            width: control.__stopSize
+            height: control.__stopSize
+            radius: control.__stopSize / 2
             scale: {
                 const centerPos = control.handleCenter;
                 const handleHalfWidth = control.mdState.handleWidth / 2;
-                const distToEnd = control.horizontal ? (parent.width - centerPos - control.rightPadding) : centerPos;
+                const distToStart = control.horizontal
+                        ? centerPos - control.leftPadding
+                        : (bgItem.height - centerPos - control.bottomPadding);
+                const clearDistance = distToStart - handleHalfWidth - 2;
+                return Math.min(Math.max(clearDistance / 2, 0), 1);
+            }
+            x: {
+                if (control.horizontal) {
+                    const stopOffset = (control.mdState.handleWidth + control.__stopSize) / 2;
+                    return control.leftPadding + stopOffset - width / 2;
+                }
+                return (bgItem.width - control.__stopSize) / 2;
+            }
+            y: {
+                if (control.horizontal) {
+                    return (bgItem.height - control.__stopSize) / 2;
+                }
+                const trackEnd = bgItem.height - control.bottomPadding;
+                const stopOffset = (control.mdState.handleWidth + control.__stopSize) / 2;
+                return trackEnd - stopOffset - height / 2;
+            }
+            color: control.mdState.trackMarkInactiveColor
+            visible: control.__showContinuousEndCaps
+        }
+
+        // Stop indicator at track end (continuous + tickVisibilityMode All only)
+        MD.Rectangle {
+            width: control.__stopSize
+            height: control.__stopSize
+            radius: control.__stopSize / 2
+            scale: {
+                const centerPos = control.handleCenter;
+                const handleHalfWidth = control.mdState.handleWidth / 2;
+                const distToEnd = control.horizontal
+                        ? (bgItem.width - centerPos - control.rightPadding)
+                        : centerPos;
                 const clearDistance = distToEnd - handleHalfWidth - 2;
                 return Math.min(Math.max(clearDistance / 2, 0), 1);
             }
             x: {
                 if (control.horizontal) {
-                    const trackEnd = parent.width - control.rightPadding;
-                    const stopOffset = (control.mdState.handleWidth + 4) / 2;
-                    return trackEnd - stopOffset;
+                    const trackEnd = bgItem.width - control.rightPadding;
+                    const stopOffset = (control.mdState.handleWidth + control.__stopSize) / 2;
+                    return trackEnd - stopOffset - width / 2;
                 }
-                return (parent.width - 4) / 2;
+                return (bgItem.width - control.__stopSize) / 2;
             }
             y: {
                 if (control.horizontal) {
-                    return (parent.height - 4) / 2;
+                    return (bgItem.height - control.__stopSize) / 2;
                 }
-                const stopOffset = (control.mdState.handleWidth - 4) / 2;
+                const stopOffset = (control.mdState.handleWidth - control.__stopSize) / 2;
                 return stopOffset;
             }
             color: control.mdState.trackMarkInactiveColor
-            visible: !control.__isDiscrete
+            visible: control.__showContinuousEndCaps
         }
 
-        // Discrete dots
+        // Discrete stop indicators
         Repeater {
             model: control.__dotCount
             delegate: MD.Rectangle {
-                width: 4
-                height: 4
-                radius: 2
+                width: control.__stopSize
+                height: control.__stopSize
+                radius: control.__stopSize / 2
                 x: {
                     if (control.horizontal) {
                         const trackWidth = control.availableWidth;
@@ -239,7 +389,7 @@ T.Slider {
                 readonly property real dotPos: control.horizontal ? x : y
                 readonly property real gapStart: control.handleCenter - bgItem.gapSize
                 readonly property real gapEnd: control.handleCenter + bgItem.gapSize
-                visible: dotPos < gapStart || dotPos > (gapEnd - 4)
+                visible: dotPos < gapStart || dotPos > (gapEnd - control.__stopSize)
 
                 required property int index
                 readonly property real currentPosition: index * control.__dotStep

--- a/qml/delegate/SliderHandle.qml
+++ b/qml/delegate/SliderHandle.qml
@@ -7,22 +7,50 @@ Item {
     implicitHeight: horizontal ? handleHeight : handleWidth
 
     property real value: 0
+    property int labelBehavior: MD.Enum.SliderLabelFloating
     property bool handleHasFocus: false
     property bool handlePressed: false
     property bool handleHovered: false
-    property int handleWidth: 12
-    property int handleHeight: 44
+    property int handleWidth: MD.Token.slider.handle_width
+    property int handleHeight: MD.Token.slider.handle_height
     property bool horizontal: false
     property int handleLineWidth: 4
 
     readonly property var control: parent
 
+    readonly property bool __valueIndicatorActive: {
+        if (root.labelBehavior === MD.Enum.SliderLabelGone)
+            return false;
+        if (root.labelBehavior === MD.Enum.SliderLabelVisible)
+            return root.control ? root.control.enabled : false;
+        return root.handlePressed || root.handleHasFocus || root.handleHovered;
+    }
+
     // The value indicator (bubble)
     MD.Control {
-        y: root.horizontal ? -height - 4 : (parent.height - height) / 2
-        x: root.horizontal ? (parent.width - width) / 2 : -width - 4
+        id: valueIndicator
+        y: {
+            if (!root.horizontal)
+                return (parent.height - height) / 2;
+            if (root.labelBehavior === MD.Enum.SliderLabelWithinBounds) {
+                const above = -height - 4;
+                const below = parent.height + 4;
+                return above >= 0 ? above : below;
+            }
+            return -height - 4;
+        }
+        x: {
+            if (root.horizontal)
+                return (parent.width - width) / 2;
+            if (root.labelBehavior === MD.Enum.SliderLabelWithinBounds) {
+                const left = -width - 4;
+                const right = parent.width + 4;
+                return left >= 0 ? left : right;
+            }
+            return -width - 4;
+        }
 
-        visible: root.handlePressed
+        visible: root.__valueIndicatorActive
         opacity: visible ? 1 : 0
         scale: visible ? 1 : 0
         Behavior on opacity {
@@ -61,10 +89,10 @@ Item {
         id: handleRect
         anchors.centerIn: parent
 
-        width: root.horizontal ? root.handleLineWidth : 44
-        height: root.horizontal ? 44 : root.handleLineWidth
+        width: root.horizontal ? root.handleLineWidth : root.handleHeight
+        height: root.horizontal ? root.handleHeight : root.handleLineWidth
 
-        radius: 2
+        radius: MD.Token.slider.track_inside_corner
         color: root.control ? root.control.mdState.backgroundColor : "transparent"
     }
 
@@ -72,9 +100,9 @@ Item {
     Rectangle {
         id: pillHandle
         anchors.centerIn: parent
-        width: (root.horizontal ? 4 : 44) + 12
-        height: (root.horizontal ? 44 : 4) + 12
-        radius: (4 + 12) / 2
+        width: (root.horizontal ? root.handleLineWidth : root.handleHeight) + 12
+        height: (root.horizontal ? root.handleHeight : root.handleLineWidth) + 12
+        radius: ((root.horizontal ? root.handleLineWidth : root.handleLineWidth) + 12) / 2
         color: "transparent"
         border.color: root.control ? root.control.mdState.backgroundColor : "transparent"
         border.width: 4

--- a/qml/state/StateSlider.qml
+++ b/qml/state/StateSlider.qml
@@ -22,8 +22,8 @@ MD.MState {
     property real trackOverlayOpacity: 0.12
 
     property int handleLineWidth: item.pressed || item.visualFocus ? 2 : 4
-    property int handleWidth: 12
-    property int handleHeight: 44
+    property int handleWidth: MD.Token.slider.handle_width
+    property int handleHeight: MD.Token.slider.handle_height
 
     Behavior on handleLineWidth {
         NumberAnimation {

--- a/src/token/token.cpp
+++ b/src/token/token.cpp
@@ -30,6 +30,7 @@ auto Token::segmented_button() const -> const SegmentedButtonSize& { return m_se
 auto Token::icon_button() const -> const IconButtonSize& { return m_icon_button; }
 auto Token::badge() const -> const BadgeSize& { return m_badge; }
 auto Token::carousel() const -> const Carousel& { return m_carousel; }
+auto Token::slider() const -> const Slider& { return m_slider; }
 auto Token::cal_curve_scale(double dpr) const -> double { return dpr >= 2.0 ? 1.0 : 4.0; }
 
 auto Token::datas() -> QQmlListProperty<QObject> { return { this, &m_datas }; }


### PR DESCRIPTION
## Summary

Brings `MD.Slider` in line with [Material 3 Slider](https://m3.material.io/components/sliders/overview): configurable value indicator, stop indicators, track sizes, and inset icon (including vertical volume-panel behavior). `MD.SliderM2` is unchanged; the demo showcases both.

- **M3 API:** `labelBehavior`, `tickVisibilityMode`, `sliderSize` (XS–XL), `insetIcon` / `insetIconAtMin`, optional `tailing` slot (horizontal)
- **Track anatomy:** active / inactive segments, line handle (`MD.SliderHandle`), optional stop dots and end caps
- **Inset icon:** thick track (M+); horizontal — icon in active/inactive segment; vertical — single icon fixed at top, falls back below handle when inactive space is too small; `insetIconAtMin` at `value == from` (Android volume panel)
- **Enums:** `SliderLabelBehavior`, `SliderTickVisibilityMode`, `SliderSize` in `MD.Enum`
- **Tokens:** `MD.Token.slider` — per-size track heights, `inset_icon_size`, `inset_icon_padding`
- **Demo:** Sliders section in `example/Components.qml` — M3 (7 horizontal + 4 vertical) and M2 (continuous / discrete / vertical)

## Architecture

| Layer | Files |
|-------|--------|
| QML control | `qml/control/Slider.qml` |
| Handle | `qml/delegate/SliderHandle.qml` |
| State | `qml/state/StateSlider.qml` |
| M2 (legacy) | `qml/control/SliderM2.qml`, `qml/delegate/SliderHandleM2.qml`, `qml/state/StateSliderM2.qml` |
| Enums | `include/qml_material/core/enum.hpp` |
| Tokens | `include/qml_material/token/token.hpp`, `src/token/token.cpp` |

## API (review focus)

| Property | Purpose |
|----------|---------|
| `labelBehavior` | `Floating` (default), `Visible`, `Gone`, `WithinBounds` — value bubble on `MD.SliderHandle` |
| `tickVisibilityMode` | `AutoLimit` (default), `All`, `None` — discrete dots + continuous end caps |
| `sliderSize` | `XSmall`…`XLarge` — track thickness; inset icon requires `>= Medium` |
| `insetIcon` / `insetIconAtMin` | Icon inside thick track; min-value icon swap |
| `insetIconSize`, `insetIconActiveColor`, `insetIconInactiveColor` | Theming hooks |
| `tailing` / `tailingSpacing` | Optional trailing `Component` on horizontal slider (reserves `rightPadding`) |
| `maxVisibleStops` | Caps decorative dots for large discrete ranges (default 20) |

**Vertical inset icon** (non-M3 guideline; matches system volume UI):

- Icon stays at the **top** of the track when there is enough inactive space above the handle
- Otherwise moves **below the handle** (same idea as horizontal inactive placement)
- Color follows the segment under the icon; icon does not ride inside the active fill
- Handle separator: same 4×44 dp line as horizontal (rotated), `z: 2` above background

## Demo (media)

<!-- Replace placeholders after upload. -->

### M3 — all variants

Horizontal: continuous, no indicators, discrete snap, discrete + stops, snap without stops, value label always, inset icon.  
Vertical grid (2×2): continuous, discrete + stops, snap without stops, inset icon (`music_note` / `volume_off`).


https://github.com/user-attachments/assets/8b54e393-b07a-45e9-856a-9e795651bbad

---

### M2 — circular handle

`MD.SliderM2` · continuous / discrete horizontal · vertical

<img width="418" height="298" alt="Screenshot from 2026-06-25 11-14-23" src="https://github.com/user-attachments/assets/212ba0f7-d4bc-4530-b286-7d7022b23d2e" />

---

## Tests

No dedicated QML scene or unit tests for `MD.Slider` in this PR.

Manual: `qm_example` → Components → Sliders.
