### PR TITLE
fix(shader): add GLSL 150/140/130 targets for desktop GPU compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,7 @@ qt_add_shaders(
   PREFIX
   "/Qcm/Material"
   GLSL
-  "300es,330"
+  "150,140,130,330,300es"
   ${SHADER_OPT}
   DEFINES
   ${SHADER_DEFINES}


### PR DESCRIPTION
## Summary

Extends `qt_add_shaders` GLSL targets so QmlMaterial shaders compile on desktop GPUs/drivers that only expose older OpenGL shader profiles.

- **Was:** `"300es,330"`
- **Now:** `"150,140,130,330,300es"`

## Problem

Shaders power core M3 visuals: rounded rectangles, shadows, blur masks, ripples (`assets/shader/*.frag`, `*.vert`). On some Linux desktop setups with legacy GL profiles, only GLSL 1.x targets are available; limiting targets to 330/300es can fail shader compilation at build or runtime.

## Changes

| File | Change |
|------|--------|
| `CMakeLists.txt` | Broader `GLSL` list in `qt_add_shaders` for target `qml_material` |

Affected shader pipeline (unchanged sources, more compile targets):

- `shadow.vert` / `shadow.frag`
- `rectangle.vert` / `rectangle.frag`
- `sdf_rectangle.frag`, `round_clip.frag`
- `blur_mask.vert` / `blur_mask.frag`
- `ripple.frag`, `rect_glow.frag`

## Review focus

- Build time / `.qsb` artifact size increase from extra GLSL variants
- Qt picks the best available variant at runtime — order in the list matters for fallback
- WebAssembly / ES-only builds — `300es` retained

## Test plan

- [ ] Clean configure + `cmake --build . --target qml_material` — green
- [ ] `qm_example` — cards, elevation, rounded images, ripples render correctly
- [ ] On a machine with older GL (if available) — no shader compile warnings in log

## Known limitations / follow-up

Non-blocking for merge:

1. No CI matrix entry for legacy GL drivers yet
2. Could gate extra targets behind a CMake option if build-time cost is a concern
