### PR TITLE
fix(carousel): aspect ratio from model pixels, disable image cache

### DIFF
--- a/qml/component/carousel/CarouselImageDelegate.qml
+++ b/qml/component/carousel/CarouselImageDelegate.qml
@@ -16,6 +16,9 @@ MD.CarouselItem {
         if (m_image.status === Image.Ready && m_image.sourceSize.height > 0) {
             return m_image.sourceSize.width / m_image.sourceSize.height;
         }
+        if (model.pixelWidth !== undefined && model.pixelHeight > 0) {
+            return model.pixelWidth / model.pixelHeight;
+        }
         if (model !== undefined && model !== null && typeof model !== 'string' && model.aspectRatio !== undefined) {
             return model.aspectRatio;
         }
@@ -89,6 +92,8 @@ MD.CarouselItem {
             radius: root.effectiveCornerRadius
             elevation: MD.Token.elevation.level0
             asynchronous: true
+            cache: false
+            inner.layer.enabled: false
         }
 
         MD.Text {


### PR DESCRIPTION
## Summary

Improves `MD.CarouselImageDelegate` for dynamic image sources whose aspect ratio is known before `Image.Ready` (e.g. custom `image://` providers, model roles).

- **Early aspect ratio:** read `model.pixelWidth` / `model.pixelHeight` before `sourceSize` is available
- **Fresh thumbnails:** `cache: false` on `MD.Image` — avoids stale frames when the URL changes for the same delegate instance
- **Rendering:** `inner.layer.enabled: false` — reduces compositing artifacts with asynchronously loaded custom images

## Problem

`itemAspectRatio` fell back to `1.0` until `Image.Ready`, causing layout jumps in carousels with per-item aspect ratios.

With dynamic providers, Qt's image cache could show a previous slice/frame after the source URL changed.

## Changes

| File | Change |
|------|--------|
| `qml/component/carousel/CarouselImageDelegate.qml` | `pixelWidth`/`pixelHeight` branch in `itemAspectRatio`; `cache: false`; `inner.layer.enabled: false` |

Priority order in `itemAspectRatio`:

1. `m_image.sourceSize` (when ready)
2. `model.pixelWidth` / `model.pixelHeight`
3. `model.aspectRatio`
4. `1.0`

## Review focus

- Role names `pixelWidth` / `pixelHeight` avoid clashing with delegate `width` / `height` injected by `CarouselView`
- `cache: false` trade-off: slightly more decode work, correct for changing URLs
- Existing demo carousels with static assets — behavior unchanged when model has no pixel roles

## Test plan

- [ ] `qm_example` → Components → Carousel (Uncontained Multi-aspect) — no regression
- [ ] Model with `pixelWidth` / `pixelHeight` roles — stable item width before image loads
- [ ] Change `imageUrl` on an existing delegate — new image shown, no stale cache
- [ ] `tests/scenes/carousel.qml` / `ctest -R carousel` — green if enabled in build

## Known limitations / follow-up

Non-blocking for merge:

1. `pixelWidth` / `pixelHeight` naming is consumer-specific; `aspectRatio` role already exists in some models
2. No unit test for early aspect-ratio path
3. `cache: false` could be opt-in via delegate property if upstream prefers default caching
