### PR TITLE
fix(textfield): align outlined notch with placeholder position

### DIFF
--- a/qml/component/TextField.qml
+++ b/qml/component/TextField.qml
@@ -16,6 +16,7 @@ MD.TextFieldEmbed {
     }
 
     font.capitalization: Font.MixedCase
+    typescale: control.mdState.typescale
     implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset, Math.max(contentWidth, m_placeholder.implicitWidth) + leftPadding + rightPadding)
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset, contentHeight + topPadding + bottomPadding)
 
@@ -59,6 +60,9 @@ MD.TextFieldEmbed {
 
         filled: control.type === MD.Enum.TextFieldFilled
         controlHasText: control.length > 0
+        cutoutColor: control.type === MD.Enum.TextFieldFilled
+                     ? control.mdState.backgroundColor
+                     : "transparent"
         //controlImplicitBackgroundHeight: control.implicitBackgroundHeight
     }
 
@@ -106,8 +110,8 @@ MD.TextFieldEmbed {
             MD.OutlineTextFieldShape {
                 borderColor: control.mdState.outlineColor
                 radius: MD.Token.shape.corner.extra_small
-                floatWidth: m_placeholder.implicitWidth * m_placeholder.targetScale + 2 + 2
-                floatX: 16 - 2
+                floatWidth: m_placeholder.implicitWidth * m_placeholder.targetScale + 8
+                floatX: m_placeholder.x - 4
                 open: control.activeFocus || control.text.length > 0
             }
         }

--- a/qml/component/textfield/FloatingPlaceholderText.qml
+++ b/qml/component/textfield/FloatingPlaceholderText.qml
@@ -7,12 +7,24 @@ Text {
     property int verticalPadding: 8
     property int controlHeight: height
     property int largestHeight: 0
+    property color cutoutColor: "transparent"
 
     property bool filled: false
     property real targetScale: 0.8
+    readonly property bool floated: controlFocus || controlHasText
     y: (controlHeight - height) / 2.0
     scale: 1.0
     verticalAlignment: Text.AlignVCenter
+
+    Rectangle {
+        z: -1
+        visible: root.floated && root.cutoutColor.a > 0
+        x: -6
+        anchors.verticalCenter: parent.verticalCenter
+        width: parent.implicitWidth * parent.scale + 12
+        height: Math.max(2, parent.largestHeight * parent.scale)
+        color: root.cutoutColor
+    }
 
     transformOrigin: {
         switch (effectiveHorizontalAlignment) {


### PR DESCRIPTION
## Summary

Fixes outlined and filled `MD.TextField` floating-label rendering when `leadingIcon` shifts the placeholder away from the default 16px inset.

- **Outlined notch:** `floatX` / `floatWidth` in `OutlineTextFieldShape` are derived from the placeholder position instead of hard-coded `16 - 2`
- **Filled cutout:** optional `cutoutColor` on `FloatingPlaceholderText` paints a background rectangle behind the floated label so the field fill does not show through the label
- **Typescale:** placeholder inherits `control.mdState.typescale` for consistent M3 typography

## Problem

With `leadingIcon`, `leftPadding` becomes `16 + 12 + iconWidth`, but the outline notch stayed at a fixed X offset. The border crossed the floating label.

Filled fields had no cutout behind the floated label — the bottom fill could visually interfere with the label.

## Changes

| File | Change |
|------|--------|
| `qml/component/TextField.qml` | `typescale` binding; `cutoutColor` for filled type; dynamic `floatX` / `floatWidth` |
| `qml/component/textfield/FloatingPlaceholderText.qml` | `cutoutColor` property; background `Rectangle` when label is floated |

## Review focus

- Notch alignment with `leadingIcon` / `trailingIcon` and RTL `effectiveHorizontalAlignment`
- Cutout only visible for `TextFieldFilled` (`cutoutColor.a > 0`)
- Animation of float transition unchanged (300ms `OutSine`)

## Test plan

- [ ] `qm_example` → Components → Text fields: outlined + filled, focus and type text — notch tracks label
- [ ] Outlined field with `leadingIcon` — notch centered on floated label, no border through text
- [ ] Filled field — label cutout matches `mdState.backgroundColor`
- [ ] `cmake --build . --target qml_material qm_example` — green

## Known limitations / follow-up

Non-blocking for merge:

1. Cutout `Rectangle` is a pragmatic fix; upstream may prefer shape-level notch for filled fields
2. `floatX: m_placeholder.x - 4` magic offset — could be tokenized
3. No automated QML test for notch geometry
