### PR TITLE
Hotfix/ci qt cmake prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,23 @@ jobs:
             fi
             export PATH="${GITHUB_WORKSPACE}/build:${GITHUB_WORKSPACE}/build/tests:${PATH}"
             export QT_QPA_PLATFORM=offscreen
-            ctest --test-dir build --output-on-failure -E "visual_" -j 2
+            export QT_ENABLE_HIGHDPI_SCALING=0
+            export QT_SCALE_FACTOR=1
+            if ! ctest --test-dir build --output-on-failure -E "visual_" -j 2; then
+              echo "==== control_layout solo -v2 ===="
+              CTRL=$(find build -name 'control_layout.exe' -type f | head -n 1)
+              if [ -z "${CTRL}" ]; then
+                CTRL=$(find build -name 'control_layout' -type f -executable | head -n 1)
+              fi
+              echo "binary=${CTRL}"
+              if [ -n "${CTRL}" ]; then
+                "${CTRL}" -v2 || true
+              else
+                echo "control_layout binary not found under build/"
+                find build -iname '*control_layout*' || true
+              fi
+              exit 1
+            fi
           elif [ "${{ runner.os }}" = "macOS" ]; then
             # No eglfs on macOS; skip visual tests.
             ctest --test-dir build --output-on-failure -E "visual_" --parallel $(sysctl -n hw.ncpu || echo 2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Icon/ typography assets are Git LFS; without this, qrc embeds
+          # pointer files and FontLoader fails (FT_New_Face error 2).
+          lfs: true
 
       # ccache for gcc / linux-clang / xcode. MSVC uses sccache instead.
       - name: Set up ccache
@@ -71,6 +75,47 @@ jobs:
           modules: 'qtshadertools'
           cache: true
           cache-key-prefix: install-qt-action-qmlmaterial-v2
+
+      # aqt kits ship no fonts; Windows offscreen FreeType needs files under
+      # lib/fonts, otherwise SnakeBar heights drift (88 vs 48). Read
+      # $QT_ROOT_DIR from the install step env — not ${{ env.QT_* }}.
+      - name: Install fallback fonts for Qt
+        shell: bash
+        run: |
+          QTDIR="${QT_ROOT_DIR:-${QTDIR:-${QT_INSTALL_DIR:-}}}"
+          if [ -z "${QTDIR}" ] || [ ! -d "${QTDIR}" ]; then
+            echo "QT_ROOT_DIR missing after Qt install"
+            exit 1
+          fi
+          export FONT_DIR="${QTDIR}/lib/fonts"
+          mkdir -p "${FONT_DIR}"
+          curl -fsSL -o /tmp/dejavu.zip \
+            "https://github.com/dejavu-fonts/dejavu-fonts/releases/download/version_2_37/dejavu-fonts-ttf-2.37.zip"
+          python3 - <<'PY'
+          import zipfile
+          from pathlib import Path
+          import os
+          font_dir = Path(os.environ["FONT_DIR"])
+          with zipfile.ZipFile("/tmp/dejavu.zip") as zf:
+              for name in zf.namelist():
+                  if name.endswith((".ttf", ".otf")) and "/ttf/" in name.replace("\\", "/"):
+                      target = font_dir / Path(name).name
+                      target.write_bytes(zf.read(name))
+          count = len(list(font_dir.glob("*.ttf")))
+          print("installed", count, "fonts into", font_dir)
+          if count < 1:
+              raise SystemExit("no fonts extracted")
+          PY
+          # Verify Material icon fonts are real TTFs (not LFS pointers).
+          for f in assets/MaterialSymbolsRounded.wght_400.opsz_24.fill_*.ttf; do
+            sz=$(wc -c < "$f")
+            echo "asset $f size=${sz}"
+            if [ "${sz}" -lt 10000 ]; then
+              echo "Material font looks like an LFS pointer; checkout lfs failed"
+              exit 1
+            fi
+          done
+          echo "QT_QPA_FONTDIR=${FONT_DIR}" >> "$GITHUB_ENV"
 
       - name: Show Qt info (debug)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,11 +76,9 @@ jobs:
           cache: true
           cache-key-prefix: install-qt-action-qmlmaterial-v2
 
-      # aqt kits ship no fonts; Windows offscreen FreeType needs files under
-      # lib/fonts, otherwise SnakeBar heights drift (88 vs 48). Read
-      # $QT_ROOT_DIR from the install step env — not ${{ env.QT_* }}.
-      # Download in Python (not curl+/tmp): native Windows Python cannot open
-      # Git Bash /tmp paths.
+      # aqt kits ship no fonts; Windows offscreen FreeType needs lib/fonts
+      # (SnakeBar heights otherwise drift). Download via Python — native
+      # Windows Python cannot open Git Bash /tmp paths.
       - name: Install fallback fonts for Qt
         shell: bash
         run: |
@@ -105,63 +103,36 @@ jobs:
               "download/version_2_37/dejavu-fonts-ttf-2.37.zip"
           )
           font_dir.mkdir(parents=True, exist_ok=True)
-          print("downloading", url, "->", zip_path)
           urllib.request.urlretrieve(url, zip_path)
           with zipfile.ZipFile(zip_path) as zf:
               for name in zf.namelist():
                   norm = name.replace("\\", "/")
                   if norm.endswith((".ttf", ".otf")) and "/ttf/" in norm:
                       (font_dir / Path(norm).name).write_bytes(zf.read(name))
-          count = len(list(font_dir.glob("*.ttf")))
-          print("installed", count, "fonts into", font_dir)
-          if count < 1:
+          if not any(font_dir.glob("*.ttf")):
               raise SystemExit("no fonts extracted")
 
-          for path in sorted(
-              Path("assets").glob("MaterialSymbolsRounded.wght_400.opsz_24.fill_*.ttf")
+          for path in Path("assets").glob(
+              "MaterialSymbolsRounded.wght_400.opsz_24.fill_*.ttf"
           ):
-              size = path.stat().st_size
-              print(f"asset {path} size={size}")
-              if size < 10000:
+              if path.stat().st_size < 10000:
                   raise SystemExit(f"Material font looks like an LFS pointer: {path}")
           PY
           echo "QT_QPA_FONTDIR=${FONT_DIR}" >> "$GITHUB_ENV"
 
-      - name: Show Qt info (debug)
-        run: |
-          QTDIR="${QT_ROOT_DIR:-${QTDIR:-$QT_INSTALL_DIR}}"
-          echo "QT_ROOT_DIR=${QT_ROOT_DIR:-}"
-          echo "QTDIR=${QTDIR}"
-          ls -la "${QTDIR}/lib/cmake" || true
-          ls -la "${QTDIR}/lib/cmake/Qt6QuickPrivate" || true
-          ls -la "${QTDIR}/lib/cmake/Qt6ShaderTools" || true
-        shell: bash
-
       - name: Verify Qt kit and ShaderTools
         run: |
-          # Same rule as Windows configure: read $QT_ROOT_DIR from the
-          # environment the install step wrote, not ${{ env.QTDIR }}.
+          # Read $QT_ROOT_DIR from the install step env, not ${{ env.QTDIR }}.
           QTDIR="${QT_ROOT_DIR:-${QTDIR:-${QT_INSTALL_DIR:-}}}"
           if [ -z "${QTDIR}" ] || [ ! -d "${QTDIR}" ]; then
             echo "QT_ROOT_DIR not set or missing after Qt install."
             exit 1
           fi
-          echo "Using QTDIR=${QTDIR}"
           if [ ! -d "${QTDIR}/lib/cmake/Qt6ShaderTools" ]; then
             echo "MISSING Qt6ShaderTools under ${QTDIR}/lib/cmake"
             ls -la "${QTDIR}/lib/cmake" || true
             exit 1
           fi
-          echo "OK Qt6ShaderTools"
-          # Private cmake packages are often absent on aqt Qt 6.8; CMake
-          # gets Qt6::QuickPrivate via Quick. Warn only.
-          for pkg in Qt6QuickPrivate Qt6GuiPrivate; do
-            if [ -d "${QTDIR}/lib/cmake/${pkg}" ]; then
-              echo "OK ${pkg}"
-            else
-              echo "WARN ${pkg} not present as a separate package (expected on Qt 6.8 aqt)"
-            fi
-          done
         shell: bash
 
       - name: Configure CMake (Linux / macOS)
@@ -181,42 +152,28 @@ jobs:
           fi
           export PATH="${QT_BIN}:${PATH}"
           export LD_LIBRARY_PATH="${QT_LIB}:${LD_LIBRARY_PATH:-}"
-          # Prefer the aqt kit. Keep distro cmake helpers as a secondary path
-          # on Linux only (pkg-config etc.), never as the only prefix.
+          # Prefer the aqt kit. Distro cmake helpers are secondary on Linux only.
           if [ "${{ runner.os }}" = "Linux" ]; then
             CMAKE_PREFIX_PATH="${QT_CMAKE_PREFIX}:/usr/lib/x86_64-linux-gnu/cmake"
           else
             CMAKE_PREFIX_PATH="${QT_CMAKE_PREFIX}"
           fi
 
-          echo "Using QTDIR=${QTDIR}"
-          echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
-          echo "which qsb: $(which qsb || true)"
-
           mkdir -p build
-          if [ "${{ runner.os }}" = "Linux" ]; then
-            if [ "${{ matrix.compiler }}" = "clang" ]; then
-              CC=clang CXX=clang++ cmake -S . -B build -G Ninja \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
-                -DQt6ShaderTools_DIR="${QT_CMAKE_PREFIX}/lib/cmake/Qt6ShaderTools" \
-                -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-            else
-              CC=gcc CXX=g++ cmake -S . -B build -G Ninja \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
-                -DQt6ShaderTools_DIR="${QT_CMAKE_PREFIX}/lib/cmake/Qt6ShaderTools" \
-                -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-            fi
+          CMAKE_ARGS=(
+            -S . -B build -G Ninja
+            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}"
+            -DQt6ShaderTools_DIR="${QT_CMAKE_PREFIX}/lib/cmake/Qt6ShaderTools"
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          )
+          if [ "${{ runner.os }}" = "Linux" ] && [ "${{ matrix.compiler }}" = "clang" ]; then
+            CC=clang CXX=clang++ cmake "${CMAKE_ARGS[@]}"
+          elif [ "${{ runner.os }}" = "Linux" ]; then
+            CC=gcc CXX=g++ cmake "${CMAKE_ARGS[@]}"
           else
-            cmake -S . -B build -G Ninja \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
-              -DQt6ShaderTools_DIR="${QT_CMAKE_PREFIX}/lib/cmake/Qt6ShaderTools" \
-              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            cmake "${CMAKE_ARGS[@]}"
           fi
         shell: bash
 
@@ -234,7 +191,6 @@ jobs:
           if (-not $qtDir) { $qtDir = $env:QTDIR }
           if (-not $qtDir) { $qtDir = $env:QT_INSTALL_DIR }
           if (-not $qtDir) { Write-Error "QT_ROOT_DIR not set - Qt install step likely failed."; exit 1 }
-          Write-Host "Using Qt dir: $qtDir"
 
           $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
           if (-not (Test-Path $vswhere)) { Write-Error "vswhere.exe not found at $vswhere"; exit 1 }
@@ -291,33 +247,7 @@ jobs:
             export QT_QPA_PLATFORM=offscreen
             export QT_ENABLE_HIGHDPI_SCALING=0
             export QT_SCALE_FACTOR=1
-            if ! ctest --test-dir build --output-on-failure -E "visual_" -j 2; then
-              echo "==== control_layout solo diagnostics ===="
-              CTRL=$(find build -name 'control_layout.exe' -type f | head -n 1)
-              if [ -z "${CTRL}" ]; then
-                CTRL=$(find build -name 'control_layout' -type f -executable | head -n 1)
-              fi
-              echo "binary=${CTRL}"
-              if [ -n "${CTRL}" ]; then
-                # QtTest stdout is often lost on Windows crash; -o writes a file.
-                set +e
-                "${CTRL}" -o control_layout_result.txt,txt -v2 \
-                  >control_layout_stdout.txt 2>control_layout_stderr.txt
-                rc=$?
-                set -e
-                echo "control_layout exit=${rc}"
-                echo "==== stdout ===="
-                cat control_layout_stdout.txt || true
-                echo "==== stderr ===="
-                cat control_layout_stderr.txt || true
-                echo "==== qt-test -o txt ===="
-                cat control_layout_result.txt || true
-              else
-                echo "control_layout binary not found under build/"
-                find build -iname '*control_layout*' || true
-              fi
-              exit 1
-            fi
+            ctest --test-dir build --output-on-failure -E "visual_" -j 2
           elif [ "${{ runner.os }}" = "macOS" ]; then
             # No eglfs on macOS; skip visual tests.
             ctest --test-dir build --output-on-failure -E "visual_" --parallel $(sysctl -n hw.ncpu || echo 2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
         run: choco install -y pkgconfiglite
         shell: powershell
 
+      # jurplel/install-qt-action v4 exports QT_ROOT_DIR (kit root with
+      # bin/lib/cmake). It does NOT export QTDIR. Do not read Qt paths via
+      # ${{ env.QTDIR }} — that expression is empty here and used to wipe
+      # CMAKE_PREFIX_PATH, so cmake picked up a system Qt without QuickPrivate.
       - name: Install Qt 6.8.3 (jurplel action)
         id: install_qt
         uses: jurplel/install-qt-action@v4
@@ -66,44 +70,70 @@ jobs:
           host: ${{ runner.os == 'macOS' && 'mac' || runner.os == 'Windows' && 'windows' || 'linux' }}
           modules: 'qtshadertools'
           cache: true
+          cache-key-prefix: install-qt-action-qmlmaterial-v2
 
       - name: Show Qt info (debug)
         run: |
           QTDIR="${QT_ROOT_DIR:-${QTDIR:-$QT_INSTALL_DIR}}"
+          echo "QT_ROOT_DIR=${QT_ROOT_DIR:-}"
           echo "QTDIR=${QTDIR}"
           ls -la "${QTDIR}/lib/cmake" || true
+          ls -la "${QTDIR}/lib/cmake/Qt6QuickPrivate" || true
+          ls -la "${QTDIR}/lib/cmake/Qt6ShaderTools" || true
         shell: bash
 
-      - name: Verify ShaderTools in Qt tree (Linux)
-        if: runner.os == 'Linux'
-        env:
-          QTDIR: ${{ env.QTDIR || env.QT_INSTALL_DIR || '/opt/Qt/6.8.3' }}
+      - name: Verify Qt private modules and ShaderTools
         run: |
-          echo "Checking for Qt6ShaderTools in ${QTDIR}"
-          if [ -d "${QTDIR}/lib/cmake/Qt6ShaderTools" ]; then
-            echo "Qt6ShaderTools found."
-            ls -la "${QTDIR}/lib/cmake/Qt6ShaderTools" || true
-            exit 0
+          # Same rule as Windows configure: read $QT_ROOT_DIR from the
+          # environment the install step wrote, not ${{ env.QTDIR }}.
+          QTDIR="${QT_ROOT_DIR:-${QTDIR:-${QT_INSTALL_DIR:-}}}"
+          if [ -z "${QTDIR}" ] || [ ! -d "${QTDIR}" ]; then
+            echo "QT_ROOT_DIR not set or missing after Qt install."
+            exit 1
           fi
-          echo "Qt6ShaderTools NOT found; installer action may not have provided it."
-          ls -la "${QTDIR}/lib/cmake" || true
+          echo "Using QTDIR=${QTDIR}"
+          missing=0
+          for pkg in Qt6QuickPrivate Qt6GuiPrivate Qt6ShaderTools; do
+            if [ -d "${QTDIR}/lib/cmake/${pkg}" ]; then
+              echo "OK ${pkg}"
+            else
+              echo "MISSING ${pkg} under ${QTDIR}/lib/cmake"
+              missing=1
+            fi
+          done
+          if [ "${missing}" -ne 0 ]; then
+            ls -la "${QTDIR}/lib/cmake" || true
+            exit 1
+          fi
         shell: bash
 
       - name: Configure CMake (Linux / macOS)
         if: runner.os != 'Windows'
-        env:
-          CMAKE_PREFIX_PATH: ${{ env.QTDIR || env.QT_INSTALL_DIR || '' }}:/usr/lib/x86_64-linux-gnu/cmake
         run: |
-          QTDIR="${QT_ROOT_DIR:-${QTDIR:-${QT_INSTALL_DIR:-/opt/Qt/6.8.3}}}"
+          QTDIR="${QT_ROOT_DIR:-${QTDIR:-${QT_INSTALL_DIR:-}}}"
+          if [ -z "${QTDIR}" ] || [ ! -d "${QTDIR}" ]; then
+            echo "QT_ROOT_DIR not set or missing after Qt install."
+            exit 1
+          fi
           if [ -d "${QTDIR}/gcc_64/bin" ]; then
             QT_BIN="${QTDIR}/gcc_64/bin"; QT_LIB="${QTDIR}/gcc_64/lib"
+            QT_CMAKE_PREFIX="${QTDIR}/gcc_64"
           else
             QT_BIN="${QTDIR}/bin"; QT_LIB="${QTDIR}/lib"
+            QT_CMAKE_PREFIX="${QTDIR}"
           fi
           export PATH="${QT_BIN}:${PATH}"
           export LD_LIBRARY_PATH="${QT_LIB}:${LD_LIBRARY_PATH:-}"
+          # Prefer the aqt kit. Keep distro cmake helpers as a secondary path
+          # on Linux only (pkg-config etc.), never as the only prefix.
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            CMAKE_PREFIX_PATH="${QT_CMAKE_PREFIX}:/usr/lib/x86_64-linux-gnu/cmake"
+          else
+            CMAKE_PREFIX_PATH="${QT_CMAKE_PREFIX}"
+          fi
 
           echo "Using QTDIR=${QTDIR}"
+          echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
           echo "which qsb: $(which qsb || true)"
 
           mkdir -p build
@@ -112,14 +142,14 @@ jobs:
               CC=clang CXX=clang++ cmake -S . -B build -G Ninja \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
-                -DQt6ShaderTools_DIR="${QTDIR}/lib/cmake/Qt6ShaderTools" \
+                -DQt6ShaderTools_DIR="${QT_CMAKE_PREFIX}/lib/cmake/Qt6ShaderTools" \
                 -DCMAKE_C_COMPILER_LAUNCHER=ccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
             else
               CC=gcc CXX=g++ cmake -S . -B build -G Ninja \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
-                -DQt6ShaderTools_DIR="${QTDIR}/lib/cmake/Qt6ShaderTools" \
+                -DQt6ShaderTools_DIR="${QT_CMAKE_PREFIX}/lib/cmake/Qt6ShaderTools" \
                 -DCMAKE_C_COMPILER_LAUNCHER=ccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
       # aqt kits ship no fonts; Windows offscreen FreeType needs files under
       # lib/fonts, otherwise SnakeBar heights drift (88 vs 48). Read
       # $QT_ROOT_DIR from the install step env — not ${{ env.QT_* }}.
+      # Download in Python (not curl+/tmp): native Windows Python cannot open
+      # Git Bash /tmp paths.
       - name: Install fallback fonts for Qt
         shell: bash
         run: |
@@ -88,33 +90,41 @@ jobs:
             exit 1
           fi
           export FONT_DIR="${QTDIR}/lib/fonts"
-          mkdir -p "${FONT_DIR}"
-          curl -fsSL -o /tmp/dejavu.zip \
-            "https://github.com/dejavu-fonts/dejavu-fonts/releases/download/version_2_37/dejavu-fonts-ttf-2.37.zip"
+          export ZIP_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+          mkdir -p "${FONT_DIR}" "${ZIP_DIR}"
           python3 - <<'PY'
+          import os
+          import urllib.request
           import zipfile
           from pathlib import Path
-          import os
+
           font_dir = Path(os.environ["FONT_DIR"])
-          with zipfile.ZipFile("/tmp/dejavu.zip") as zf:
+          zip_path = Path(os.environ["ZIP_DIR"]) / "dejavu-fonts-ttf-2.37.zip"
+          url = (
+              "https://github.com/dejavu-fonts/dejavu-fonts/releases/"
+              "download/version_2_37/dejavu-fonts-ttf-2.37.zip"
+          )
+          font_dir.mkdir(parents=True, exist_ok=True)
+          print("downloading", url, "->", zip_path)
+          urllib.request.urlretrieve(url, zip_path)
+          with zipfile.ZipFile(zip_path) as zf:
               for name in zf.namelist():
-                  if name.endswith((".ttf", ".otf")) and "/ttf/" in name.replace("\\", "/"):
-                      target = font_dir / Path(name).name
-                      target.write_bytes(zf.read(name))
+                  norm = name.replace("\\", "/")
+                  if norm.endswith((".ttf", ".otf")) and "/ttf/" in norm:
+                      (font_dir / Path(norm).name).write_bytes(zf.read(name))
           count = len(list(font_dir.glob("*.ttf")))
           print("installed", count, "fonts into", font_dir)
           if count < 1:
               raise SystemExit("no fonts extracted")
+
+          for path in sorted(
+              Path("assets").glob("MaterialSymbolsRounded.wght_400.opsz_24.fill_*.ttf")
+          ):
+              size = path.stat().st_size
+              print(f"asset {path} size={size}")
+              if size < 10000:
+                  raise SystemExit(f"Material font looks like an LFS pointer: {path}")
           PY
-          # Verify Material icon fonts are real TTFs (not LFS pointers).
-          for f in assets/MaterialSymbolsRounded.wght_400.opsz_24.fill_*.ttf; do
-            sz=$(wc -c < "$f")
-            echo "asset $f size=${sz}"
-            if [ "${sz}" -lt 10000 ]; then
-              echo "Material font looks like an LFS pointer; checkout lfs failed"
-              exit 1
-            fi
-          done
           echo "QT_QPA_FONTDIR=${FONT_DIR}" >> "$GITHUB_ENV"
 
       - name: Show Qt info (debug)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,12 @@ jobs:
         run: |
           if [ "${{ runner.os }}" = "Windows" ]; then
             # Visual tests need EGL/DRM or ANGLE; skip on Windows.
+            QTDIR="${QT_ROOT_DIR:-${QTDIR:-${QT_INSTALL_DIR:-}}}"
+            if [ -n "${QTDIR}" ]; then
+              export PATH="${QTDIR}/bin:${PATH}"
+            fi
+            export PATH="${GITHUB_WORKSPACE}/build:${GITHUB_WORKSPACE}/build/tests:${PATH}"
+            export QT_QPA_PLATFORM=offscreen
             ctest --test-dir build --output-on-failure -E "visual_" -j 2
           elif [ "${{ runner.os }}" = "macOS" ]; then
             # No eglfs on macOS; skip visual tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           ls -la "${QTDIR}/lib/cmake/Qt6ShaderTools" || true
         shell: bash
 
-      - name: Verify Qt private modules and ShaderTools
+      - name: Verify Qt kit and ShaderTools
         run: |
           # Same rule as Windows configure: read $QT_ROOT_DIR from the
           # environment the install step wrote, not ${{ env.QTDIR }}.
@@ -92,19 +92,21 @@ jobs:
             exit 1
           fi
           echo "Using QTDIR=${QTDIR}"
-          missing=0
-          for pkg in Qt6QuickPrivate Qt6GuiPrivate Qt6ShaderTools; do
-            if [ -d "${QTDIR}/lib/cmake/${pkg}" ]; then
-              echo "OK ${pkg}"
-            else
-              echo "MISSING ${pkg} under ${QTDIR}/lib/cmake"
-              missing=1
-            fi
-          done
-          if [ "${missing}" -ne 0 ]; then
+          if [ ! -d "${QTDIR}/lib/cmake/Qt6ShaderTools" ]; then
+            echo "MISSING Qt6ShaderTools under ${QTDIR}/lib/cmake"
             ls -la "${QTDIR}/lib/cmake" || true
             exit 1
           fi
+          echo "OK Qt6ShaderTools"
+          # Private cmake packages are often absent on aqt Qt 6.8; CMake
+          # gets Qt6::QuickPrivate via Quick. Warn only.
+          for pkg in Qt6QuickPrivate Qt6GuiPrivate; do
+            if [ -d "${QTDIR}/lib/cmake/${pkg}" ]; then
+              echo "OK ${pkg}"
+            else
+              echo "WARN ${pkg} not present as a separate package (expected on Qt 6.8 aqt)"
+            fi
+          done
         shell: bash
 
       - name: Configure CMake (Linux / macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,14 +236,26 @@ jobs:
             export QT_ENABLE_HIGHDPI_SCALING=0
             export QT_SCALE_FACTOR=1
             if ! ctest --test-dir build --output-on-failure -E "visual_" -j 2; then
-              echo "==== control_layout solo -v2 ===="
+              echo "==== control_layout solo diagnostics ===="
               CTRL=$(find build -name 'control_layout.exe' -type f | head -n 1)
               if [ -z "${CTRL}" ]; then
                 CTRL=$(find build -name 'control_layout' -type f -executable | head -n 1)
               fi
               echo "binary=${CTRL}"
               if [ -n "${CTRL}" ]; then
-                "${CTRL}" -v2 || true
+                # QtTest stdout is often lost on Windows crash; -o writes a file.
+                set +e
+                "${CTRL}" -o control_layout_result.txt,txt -v2 \
+                  >control_layout_stdout.txt 2>control_layout_stderr.txt
+                rc=$?
+                set -e
+                echo "control_layout exit=${rc}"
+                echo "==== stdout ===="
+                cat control_layout_stdout.txt || true
+                echo "==== stderr ===="
+                cat control_layout_stderr.txt || true
+                echo "==== qt-test -o txt ===="
+                cat control_layout_result.txt || true
               else
                 echo "control_layout binary not found under build/"
                 find build -iname '*control_layout*' || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,7 @@ jobs:
             cmake -S . -B build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
+              -DQt6ShaderTools_DIR="${QT_CMAKE_PREFIX}/lib/cmake/Qt6ShaderTools" \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,12 @@ if(UNIX AND NOT APPLE)
   set(LINUX CACHE INTERNAL TRUE "")
 endif()
 
-find_package(Qt6 REQUIRED COMPONENTS Core Quick QuickControls2 Gui Qml ShaderTools QuickPrivate)
+find_package(Qt6 REQUIRED COMPONENTS Core Quick QuickControls2 Gui Qml ShaderTools)
+# Qt < ~6.9 often exposes Qt6::QuickPrivate via Quick; Qt 6.9+ needs an
+# explicit private package (aqt 6.8.3 CI has no Qt6QuickPrivateConfig).
+if(NOT TARGET Qt6::QuickPrivate)
+  find_package(Qt6 REQUIRED COMPONENTS QuickPrivate)
+endif()
 
 if(UNIX AND NOT ANDROID AND NOT EMSCRIPTEN)
   find_package(Qt6 REQUIRED COMPONENTS DBus)

--- a/cmake/qml_material-config.cmake.in
+++ b/cmake/qml_material-config.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Qt6 COMPONENTS Core Quick QuickControls2 Gui Qml ShaderTools QuickPrivate)
+find_dependency(Qt6 COMPONENTS Core Quick QuickControls2 Gui Qml ShaderTools)
 
 include("${CMAKE_CURRENT_LIST_DIR}/qml_material-targets.cmake")
 check_required_components(qml_material)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -140,7 +140,8 @@ set_target_properties(control_layout PROPERTIES AUTOMOC ON)
 qt_import_qml_plugins(control_layout)
 add_test(NAME control_layout COMMAND control_layout)
 set_tests_properties(control_layout PROPERTIES
-  ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QML_IMPORT_PATH=${QT_QML_OUTPUT_DIRECTORY}")
+  RUN_SERIAL ON
+  ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_ENABLE_HIGHDPI_SCALING=0;QT_SCALE_FACTOR=1;QML_IMPORT_PATH=${QT_QML_OUTPUT_DIRECTORY}")
 
 set(VISUAL_SCENES button action_progress elevation shape ripple ripple_phases loading_indicator_shapes tooltip wave_progress snackbar
     focus_button focus_iconbutton focus_fab focus_chip

--- a/tests/control_layout.cpp
+++ b/tests/control_layout.cpp
@@ -49,6 +49,26 @@ class ControlLayoutTest : public QObject {
     Q_OBJECT
 
 private Q_SLOTS:
+    void initTestCase() {
+        qputenv("QT_ENABLE_HIGHDPI_SCALING", "0");
+        m_engine.addImportPath(QCoreApplication::applicationDirPath()
+                               + QStringLiteral("/../qml_modules"));
+        const QByteArray envPath = qgetenv("QML_IMPORT_PATH");
+        if (!envPath.isEmpty()) {
+#if defined(Q_OS_WIN)
+            const QList<QByteArray> parts = envPath.split(';');
+#else
+            const QList<QByteArray> parts = envPath.split(':');
+#endif
+            for (const QByteArray& part : parts) {
+                if (!part.isEmpty())
+                    m_engine.addImportPath(QString::fromLocal8Bit(part));
+            }
+        }
+        m_window.setGeometry(0, 0, 800, 600);
+        m_window.create();
+    }
+
     void constrainedTextElides_data() {
         QTest::addColumn<QString>("type");
         QTest::addColumn<QString>("setup");
@@ -398,9 +418,11 @@ private Q_SLOTS:
         QCoreApplication::processEvents();
 
         QQuickItem* delegate = nullptr;
-        QVERIFY(QMetaObject::invokeMethod(
-            menu, "itemAt", Q_RETURN_ARG(QQuickItem*, delegate), Q_ARG(int, 0)));
-        QVERIFY(delegate);
+        QTRY_VERIFY_WITH_TIMEOUT(
+            QMetaObject::invokeMethod(
+                menu, "itemAt", Q_RETURN_ARG(QQuickItem*, delegate), Q_ARG(int, 0))
+                && delegate,
+            3000);
         settle(delegate);
         QCOMPARE(menu->property("count").toInt(), 1);
         QCOMPARE(menu->property("implicitContentWidth").toReal(), delegate->implicitWidth());

--- a/tests/control_layout.cpp
+++ b/tests/control_layout.cpp
@@ -56,18 +56,17 @@ class ControlLayoutTest : public QObject {
 
 private Q_SLOTS:
     void initTestCase() {
-        qputenv("QT_ENABLE_HIGHDPI_SCALING", "0");
         m_engine.addImportPath(QCoreApplication::applicationDirPath()
                                + QStringLiteral("/../qml_modules"));
         const QByteArray envPath = qgetenv("QML_IMPORT_PATH");
-        if (!envPath.isEmpty()) {
+        if (! envPath.isEmpty()) {
 #if defined(Q_OS_WIN)
             const QList<QByteArray> parts = envPath.split(';');
 #else
             const QList<QByteArray> parts = envPath.split(':');
 #endif
             for (const QByteArray& part : parts) {
-                if (!part.isEmpty())
+                if (! part.isEmpty())
                     m_engine.addImportPath(QString::fromLocal8Bit(part));
             }
         }

--- a/tests/control_layout.cpp
+++ b/tests/control_layout.cpp
@@ -1,11 +1,17 @@
 #include <QCoreApplication>
 #include <QFont>
+#include <QGuiApplication>
 #include <QQmlComponent>
 #include <QQmlEngine>
 #include <QQuickItem>
 #include <QQuickWindow>
 #include <QtTest>
 #include <memory>
+
+#ifdef Q_OS_WIN
+#    include <QAbstractNativeEventFilter>
+#    include <windows.h>
+#endif
 
 #include "qml_material/layout/layout_container.hpp"
 
@@ -924,6 +930,35 @@ private:
     QQuickWindow m_window;
 };
 
-QTEST_MAIN(ControlLayoutTest)
+#ifdef Q_OS_WIN
+// Same workaround as example/main.cpp: Windows UIA + Qt accessibility can
+// crash while Material controls are created/pressed.
+class UiaBlocker : public QAbstractNativeEventFilter {
+public:
+    bool nativeEventFilter(const QByteArray& eventType, void* message, qintptr* result) override {
+        if (eventType == "windows_generic_MSG") {
+            if (static_cast<MSG*>(message)->message == WM_GETOBJECT) {
+                *result = 0;
+                return true;
+            }
+        }
+        return false;
+    }
+};
+#endif
+
+int main(int argc, char* argv[]) {
+    qputenv("QT_ENABLE_HIGHDPI_SCALING", "0");
+    qputenv("QT_SCALE_FACTOR", "1");
+
+    QGuiApplication app(argc, argv);
+#ifdef Q_OS_WIN
+    static UiaBlocker uiaBlocker;
+    app.installNativeEventFilter(&uiaBlocker);
+#endif
+
+    ControlLayoutTest tc;
+    return QTest::qExec(&tc, argc, argv);
+}
 
 #include "control_layout.moc"


### PR DESCRIPTION
- Fix CI Qt discovery: stop using empty ${{ env.QTDIR }}; prefer QT_ROOT_DIR from install-qt-action, and find QuickPrivate only when the target is missing (aqt Qt 6.8).

- Make Windows control_layout reliable: checkout with Git LFS so Material icon fonts are real TTFs, seed DejaVu into Qt lib/fonts, and keep HiDPI/UiaBlocker hardening for offscreen MSVC runs.

- Align Linux/macOS CMake configure (Qt6ShaderTools_DIR, shared args) and drop temporary debug diagnostics once CI was green.