### PR TITLE
Adding fractional steps into slider

### DIFF
--- a/example/Components.qml
+++ b/example/Components.qml
@@ -1289,6 +1289,20 @@ MD.Page {
                                     labelBehavior: MD.Enum.SliderLabelVisible
                                 }
                                 MD.Text {
+                                    text: 'Fractional step (auto decimals)'
+                                    typescale: MD.Token.typescale.label_medium
+                                    opacity: 0.8
+                                }
+                                MD.Slider {
+                                    Layout.fillWidth: true
+                                    from: 0
+                                    to: 1
+                                    stepSize: 0.1
+                                    snapMode: T.Slider.SnapAlways
+                                    value: 0.5
+                                    labelBehavior: MD.Enum.SliderLabelVisible
+                                }
+                                MD.Text {
                                     text: 'Inset icon'
                                     typescale: MD.Token.typescale.label_medium
                                     opacity: 0.8

--- a/qml/control/Slider.qml
+++ b/qml/control/Slider.qml
@@ -20,6 +20,7 @@ T.Slider {
     property int labelBehavior: MD.Enum.SliderLabelFloating
     property int tickVisibilityMode: MD.Enum.SliderTickAutoLimit
     property int sliderSize: MD.Enum.SliderSizeXSmall
+    property int valueLabelDecimals: -1
 
     property string insetIcon: ''
     property string insetIconAtMin: ''
@@ -61,6 +62,20 @@ T.Slider {
 
     readonly property real __steps: Math.abs(to - from) / stepSize
     readonly property bool __isDiscrete: stepSize >= Number.EPSILON && snapMode === Slider.SnapAlways && Math.abs(Math.round(__steps) - __steps) < Number.EPSILON
+    readonly property int __resolvedValueLabelDecimals: {
+        if (control.valueLabelDecimals >= 0)
+            return control.valueLabelDecimals;
+        if (!(control.stepSize > 0))
+            return 0;
+
+        let step = Math.abs(control.stepSize);
+        let decimals = 0;
+        while (decimals < 6 && Math.abs(step - Math.round(step)) > 1e-6) {
+            step *= 10;
+            ++decimals;
+        }
+        return decimals;
+    }
 
     // Cap visible tick dots so wide ranges (e.g. 1..240 step 1) don't
     // collapse into a solid line. Snap behavior stays driven by
@@ -186,6 +201,7 @@ T.Slider {
             return control.topPadding + offset;
         }
         value: control.value
+        valueLabelDecimals: control.__resolvedValueLabelDecimals
         labelBehavior: control.labelBehavior
         handleHasFocus: control.visualFocus
         handlePressed: control.pressed

--- a/qml/delegate/SliderHandle.qml
+++ b/qml/delegate/SliderHandle.qml
@@ -7,6 +7,7 @@ Item {
     implicitHeight: horizontal ? handleHeight : handleWidth
 
     property real value: 0
+    property int valueLabelDecimals: 0
     property int labelBehavior: MD.Enum.SliderLabelFloating
     property bool handleHasFocus: false
     property bool handlePressed: false
@@ -32,6 +33,12 @@ Item {
         if (max < min)
             return min;
         return Math.min(Math.max(preferred, min), max);
+    }
+
+    function formatValueLabel(value) {
+        if (root.valueLabelDecimals <= 0)
+            return Math.round(value).toString();
+        return Number(value).toFixed(root.valueLabelDecimals);
     }
 
     // The value indicator (bubble)
@@ -92,7 +99,7 @@ Item {
             implicitWidth: children[0].implicitWidth
             MD.Text {
                 anchors.centerIn: parent
-                text: Math.round(root.value)
+                text: root.formatValueLabel(root.value)
                 typescale: MD.Token.typescale.label_medium
                 color: root.control ? root.control.mdState.ctx.color.inverse_on_surface : "transparent"
             }


### PR DESCRIPTION
## Summary

Makes `MD.Slider` value indicator show fractional values when `stepSize` is not an integer (e.g. `0.1` no longer rounds the bubble to `0`).


- **API:** `valueLabelDecimals` on `MD.Slider` (`-1` default = auto from `stepSize`, or force `N >= 0`)
- **Handle:** `formatValueLabel` uses `toFixed(N)` / `Math.round` for integer steps
- **Demo:** Components → Sliders → Fractional step (auto decimals)

## Problem

The value bubble always used `Math.round(root.value)`. Discrete sliders with `stepSize: 0.1` snapped correctly but the label showed integers only.

## Changes

| File | Change |
|------|--------|
| `qml/control/Slider.qml` | `valueLabelDecimals`, `__resolvedValueLabelDecimals`, pass to handle |
| `qml/delegate/SliderHandle.qml` | `valueLabelDecimals`, `formatValueLabel`, wire bubble text |
| `example/Components.qml` | Fractional step demo (`0..1`, `stepSize: 0.1`) |

## Review focus

- Auto decimals from `stepSize` (`0.1` → 1, integer step → 0), capped at 6
- Explicit `valueLabelDecimals: N` overrides auto
- Continuous / integer discrete sliders keep rounded labels (backward-compatible)
- `SliderM2` unchanged

## Test plan

- [ ] `qm_example` → Components → Sliders → **Fractional step** — bubble shows `0.5`, `0.6`, … while dragging
- [ ] Continuous / Value label always — still integer text
- [ ] Discrete snap with `stepSize: 20` — still integer text
- [ ] Override `valueLabelDecimals: 2` on a float-step slider — two decimal places
- [ ] `cmake --build . --target qml_material qm_example` — green

## Known limitations / follow-up

Non-blocking for merge:

1. No automated QML/unit tests for label formatting
2. `MD.SliderM2` value indicator (if any) does not get `valueLabelDecimals`
3. Auto detection stops at 6 fractional digits