### PR TITLE
fix Dialog TypeError when parent is null

### DIFF
--- a/qml/control/Dialog.qml
+++ b/qml/control/Dialog.qml
@@ -26,10 +26,10 @@ T.Dialog {
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset, contentHeight + topPadding + bottomPadding + (implicitHeaderHeight > 0 ? implicitHeaderHeight + spacing : 0) + (implicitFooterHeight > 0 ? implicitFooterHeight + spacing : 0))
 
     width: Math.min(implicitWidth, 560)
-    height: Math.min(implicitHeight, parent.height - 48 * 2)
+    height: Math.min(implicitHeight, parent ? parent.height - 48 * 2 : implicitHeight)
 
-    x: (parent.width - width) / 2
-    y: (parent.height - height) / 2
+    x: parent ? (parent.width - width) / 2 : 0
+    y: parent ? (parent.height - height) / 2 : 0
 
     spacing: 0
     topPadding: 12


### PR DESCRIPTION
## Summary
`Dialog` binds `height`, `x`, and `y` to `parent.width` / `parent.height` without a null check.

When the dialog’s parent (e.g. `Overlay.overlay`) is destroyed during application shutdown, those bindings still re-evaluate and spam:
```shell
qrc:/Qcm/Material/qml/control/Dialog.qml:29: TypeError: Cannot read property 'height' of null
qrc:/Qcm/Material/qml/control/Dialog.qml:31: TypeError: Cannot read property 'width' of null
qrc:/Qcm/Material/qml/control/Dialog.qml:32: TypeError: Cannot read property 'height' of null
```
