### PR TITLE
do not force per-word capitalization on labels

### DIFF
--- a/qml/component/appbar/AppBar.qml
+++ b/qml/component/appbar/AppBar.qml
@@ -38,7 +38,7 @@ T.ToolBar {
 
         MD.Text {
             id: m_title
-            font.capitalization: Font.Capitalize
+            font.capitalization: Font.MixedCase
             typescale: control.mdState.typescale
             Binding {
                 when: control.type === MD.Enum.AppBarCenterAligned

--- a/qml/component/appbar/BarItem.qml
+++ b/qml/component/appbar/BarItem.qml
@@ -51,7 +51,7 @@ T.Button {
 
             MD.Text {
                 Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
-                font.capitalization: Font.Capitalize
+                font.capitalization: Font.MixedCase
                 typescale: MD.Token.typescale.label_medium
                 text: control.text
                 prominent: control.checked

--- a/qml/component/chip/AssistChip.qml
+++ b/qml/component/chip/AssistChip.qml
@@ -30,7 +30,7 @@ T.Button {
     icon.height: 18
 
     property MD.typescale typescale: MD.Token.typescale.label_large
-    font.capitalization: Font.Capitalize
+    font.capitalization: Font.MixedCase
     font.pixelSize: typescale.size
     font.weight: typescale.weight
     font.letterSpacing: typescale.tracking

--- a/qml/component/chip/EmbedChip.qml
+++ b/qml/component/chip/EmbedChip.qml
@@ -30,7 +30,7 @@ T.Button {
     icon.width: 18
     icon.height: 18
     action: null
-    font.capitalization: Font.Capitalize
+    font.capitalization: Font.MixedCase
 
     property string trailingIconName
     property Component leading: m_leading_comp

--- a/qml/component/chip/FilterChip.qml
+++ b/qml/component/chip/FilterChip.qml
@@ -33,7 +33,7 @@ T.Button {
 
     icon.width: 18
     icon.height: 18
-    font.capitalization: Font.Capitalize
+    font.capitalization: Font.MixedCase
 
     contentItem: Lite.Row {
         alignment: Qt.AlignHCenter | Qt.AlignVCenter

--- a/qml/component/chip/SuggestionChip.qml
+++ b/qml/component/chip/SuggestionChip.qml
@@ -29,7 +29,7 @@ T.Button {
     icon.width: 18
     icon.height: 18
     property MD.typescale typescale: MD.Token.typescale.label_large
-    font.capitalization: Font.Capitalize
+    font.capitalization: Font.MixedCase
     font.pixelSize: typescale.size
     font.weight: typescale.weight
     font.letterSpacing: typescale.tracking

--- a/qml/component/navigation/DrawerItem.qml
+++ b/qml/component/navigation/DrawerItem.qml
@@ -25,7 +25,7 @@ T.ItemDelegate {
     icon.width: 24
     icon.height: 24
 
-    font.capitalization: Font.Capitalize
+    font.capitalization: Font.MixedCase
 
     property alias trailing: item_holder_trailing.contentItem
 

--- a/qml/component/navigation/RailItem.qml
+++ b/qml/component/navigation/RailItem.qml
@@ -115,7 +115,7 @@ T.Button {
             id: m_label
             visible: control._showLabel
             text: control.text
-            font.capitalization: Font.Capitalize
+            font.capitalization: Font.MixedCase
             typescale: control.expand ? MD.Token.typescale.label_large : MD.Token.typescale.label_medium
             prominent: control.checked
             color: control.expand ? control.mdState.expandedLabelColor : control.mdState.collapsedLabelColor

--- a/qml/control/MenuItem.qml
+++ b/qml/control/MenuItem.qml
@@ -57,7 +57,7 @@ T.MenuItem {
     }
 
     property MD.typescale typescale: MD.Token.typescale.label_large
-    font.capitalization: Font.Capitalize
+    font.capitalization: Font.MixedCase
     font.pixelSize: typescale.size
     font.weight: typescale.weight
     font.letterSpacing: typescale.tracking

--- a/qml/control/Page.qml
+++ b/qml/control/Page.qml
@@ -32,7 +32,7 @@ T.Page {
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset, contentHeight + topPadding + bottomPadding + (implicitHeaderHeight > 0 ? implicitHeaderHeight + spacing : 0) + (implicitFooterHeight > 0 ? implicitFooterHeight + spacing : 0))
 
     // bottomPadding: header.visible ? radius : 0
-    font.capitalization: Font.Capitalize
+    font.capitalization: Font.MixedCase
 
     background: MD.Rectangle {
         color: control.backgroundColor

--- a/qml/control/TabButton.qml
+++ b/qml/control/TabButton.qml
@@ -37,7 +37,7 @@ T.TabButton {
     icon.height: 24
 
     property MD.typescale typescale: MD.Token.typescale.label_medium
-    font.capitalization: Font.Capitalize
+    font.capitalization: Font.MixedCase
     font.pixelSize: typescale.size
     font.weight: typescale.weight
     font.letterSpacing: typescale.tracking


### PR DESCRIPTION

Font.Capitalize uppercases the first letter of every word, so any language that
writes headings in sentence case gets rewritten on screen. The strings in the
catalogue are already correct; only the rendering is not. In a Russian build the
rail entry "О программе" is drawn as "О Программе", the sort menu entry
"Дата изменения" as "Дата Изменения", and the chip "В тренде" as "В Тренде".

It is wrong for English too: a source string written as "Last modified" is drawn
as "Last Modified". Material 3 asks for sentence case in navigation labels, menu
items, tabs, chips and app bar titles, and Button.qml already sets
Font.MixedCase with the comment "M3 uses mixed case" — this brings the remaining
11 components in line with it.

Checked in a real Qt 6.11 application built against this branch: the Russian
labels above render correctly and the English UI is unchanged apart from
"Last Modified" becoming "Last modified", which is what the source string says.
