### PR TITLE
fix MD.Icon rendering artifacts on vertical-stroke glyphs 

### DIFF
--- a/qml/component/extra/Icon.qml
+++ b/qml/component/extra/Icon.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Window
 import Qcm.Material as MD
 
 Item {
@@ -15,7 +14,6 @@ Item {
     property alias horizontalAlignment: m_text_icon.horizontalAlignment
     property alias verticalAlignment: m_text_icon.verticalAlignment
 
-    property int lineHeight: MD.Token.typescale.label_large.line_height
     property color color: MD.MProp.color.on_background
 
     property real _fill: fill ? 1 : 0
@@ -39,7 +37,6 @@ Item {
     Text {
         id: m_text_icon
         anchors.centerIn: parent
-        renderType: Text.CurveRendering
 
         font.family: root.fill ? MD.Token.font.icon_fill_family : MD.Token.font.icon_family
         font.weight: root.weight
@@ -51,14 +48,13 @@ Item {
                 "FILL": root._fillSeg
             };
         }
-        font.pixelSize: root.size / scale
-        scale: 1.0 / MD.Token.cal_curve_scale(Screen.devicePixelRatio)
+        font.pixelSize: root.size
 
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
         text: root.name
         color: root.color
-        lineHeight: root.lineHeight
+        lineHeight: font.pixelSize
         lineHeightMode: Text.FixedHeight
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -166,6 +166,7 @@ set_tests_properties(dynamic_creation PROPERTIES
   ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QML_IMPORT_PATH=${QT_QML_OUTPUT_DIRECTORY}")
 
 set(VISUAL_SCENES button action_progress elevation shape ripple ripple_phases loading_indicator_shapes tooltip wave_progress snackbar
+    icon_artifacts
     focus_button focus_iconbutton focus_fab focus_chip
     focus_switch focus_checkbox focus_radio
     datepicker colorpicker colorpicker_button

--- a/tests/control_layout.cpp
+++ b/tests/control_layout.cpp
@@ -95,6 +95,37 @@ qml_material::Row* layoutRow(QQuickItem* root) {
     return nullptr;
 }
 
+QQuickItem* innerTextItem(QQuickItem* root) {
+    if (root->property("font").isValid() && root->property("text").isValid()) {
+        return root;
+    }
+    for (auto* child : root->childItems()) {
+        if (auto* match = innerTextItem(child)) {
+            return match;
+        }
+    }
+    return nullptr;
+}
+
+int curveRenderingType(QQmlEngine& engine) {
+    static int cached = -1;
+    if (cached >= 0) {
+        return cached;
+    }
+    QQmlComponent component(&engine);
+    component.setData(
+        QByteArrayLiteral("import QtQuick\nQtObject { property int v: Text.CurveRendering }"),
+        QUrl(QStringLiteral("qrc:/tests/curve-rendering-enum.qml")));
+    if (component.isError()) {
+        return cached = 0;
+    }
+    std::unique_ptr<QObject> object(component.create());
+    if (! object) {
+        return cached = 0;
+    }
+    return cached = object->property("v").toInt();
+}
+
 } // namespace
 
 class ControlLayoutTest : public QObject {
@@ -1538,6 +1569,90 @@ private Q_SLOTS:
         QVERIFY(snakeBar);
         QCOMPARE(snakeBar->property("actionOnNewLine").toBool(), true);
         QCOMPARE(snakeBar->implicitHeight(), 112.0);
+    }
+
+    void iconRenderingMatchesFabPath_data() {
+        QTest::addColumn<int>("size");
+
+        QTest::newRow("18") << 18;
+        QTest::newRow("20") << 20;
+        QTest::newRow("24") << 24;
+    }
+
+    void iconRenderingMatchesFabPath() {
+        QFETCH(int, size);
+
+        const auto source = QStringLiteral(R"(
+            import QtQuick
+            import Qcm.Material as MD
+
+            MD.Icon {
+                id: icon
+                name: MD.Token.icon.content_copy
+                size: %1
+            }
+        )")
+                                .arg(size)
+                                .toUtf8();
+
+        QQmlComponent component(&m_engine);
+        component.setData(source, QUrl(QStringLiteral("qrc:/tests/icon-rendering.qml")));
+        QVERIFY2(! component.isError(), qPrintable(component.errorString()));
+
+        std::unique_ptr<QObject> object(component.create());
+        QVERIFY2(object, qPrintable(component.errorString()));
+        auto* icon = qobject_cast<QQuickItem*>(object.get());
+        QVERIFY(icon);
+        icon->setParentItem(m_window.contentItem());
+        settle(icon);
+
+        QCOMPARE(icon->implicitWidth(), qreal(size));
+        QCOMPARE(icon->implicitHeight(), qreal(size));
+
+        auto* text = innerTextItem(icon);
+        QVERIFY(text);
+        const auto font = qvariant_cast<QFont>(text->property("font"));
+        QCOMPARE(font.pixelSize(), size);
+        QCOMPARE(text->property("lineHeight").toReal(), qreal(font.pixelSize()));
+        QCOMPARE(text->scale(), 1.0);
+        QVERIFY(text->property("renderType").toInt() != curveRenderingType(m_engine));
+    }
+
+    void iconButtonContentIconSize() {
+        const auto source = QByteArrayLiteral(R"(
+            import QtQuick
+            import Qcm.Material as MD
+
+            MD.IconButton {
+                id: button
+                icon.name: MD.Token.icon.delete
+            }
+        )");
+
+        QQmlComponent component(&m_engine);
+        component.setData(source, QUrl(QStringLiteral("qrc:/tests/icon-button-icon-size.qml")));
+        QVERIFY2(! component.isError(), qPrintable(component.errorString()));
+
+        std::unique_ptr<QObject> object(component.create());
+        QVERIFY2(object, qPrintable(component.errorString()));
+        auto* button = qobject_cast<QQuickItem*>(object.get());
+        QVERIFY(button);
+        button->setParentItem(m_window.contentItem());
+        settle(button);
+
+        auto* mdState = qvariant_cast<QObject*>(button->property("mdState"));
+        QVERIFY(mdState);
+        const qreal iconSize = mdState->property("iconSize").toReal();
+        QCOMPARE(iconSize, 24.0);
+
+        auto* content = qvariant_cast<QQuickItem*>(button->property("contentItem"));
+        QVERIFY(content);
+        QCOMPARE(content->implicitWidth(), iconSize);
+        QCOMPARE(content->implicitHeight(), iconSize);
+
+        auto* icon = itemWithIcon(content);
+        QVERIFY(icon);
+        QCOMPARE(icon->property("size").toInt(), qRound(iconSize));
     }
 
 private:

--- a/tests/scenes/icon_artifacts.qml
+++ b/tests/scenes/icon_artifacts.qml
@@ -1,0 +1,134 @@
+import QtQuick
+import QtQuick.Layouts
+import Qcm.Material as MD
+
+// Visual regression repro for MD.Icon on vertical-stroke glyphs (copy, delete, videocam).
+// Top row: IconButton → MD.Icon (lineHeight = pixelSize, default renderType).
+// Middle row: FAB-style Text reference (lineHeight = pixelSize).
+// Bottom: raw MD.Icon at typical iconSize values (18 / 20 / 24).
+Rectangle {
+    id: root
+    width: 560
+    height: 420
+    color: MD.Token.color.surface
+
+    readonly property var artifactIcons: [
+        { label: "content_copy", name: MD.Token.icon.content_copy },
+        { label: "delete", name: MD.Token.icon.delete },
+        { label: "videocam", name: MD.Token.icon.videocam }
+    ]
+    readonly property var iconSizes: [18, 20, 24]
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 16
+        spacing: 12
+
+        MD.Text {
+            text: "IconButton (MD.Icon)"
+            typescale: MD.Token.typescale.label_large
+        }
+
+        RowLayout {
+            spacing: 16
+            Repeater {
+                model: root.artifactIcons
+                delegate: ColumnLayout {
+                    required property var modelData
+                    spacing: 4
+                    MD.Text {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: modelData.label
+                        typescale: MD.Token.typescale.label_small
+                    }
+                    MD.IconButton {
+                        Layout.alignment: Qt.AlignHCenter
+                        icon.name: modelData.name
+                    }
+                }
+            }
+        }
+
+        MD.Text {
+            text: "FAB Text reference (lineHeight = pixelSize)"
+            typescale: MD.Token.typescale.label_large
+        }
+
+        RowLayout {
+            spacing: 16
+            Repeater {
+                model: root.artifactIcons
+                delegate: ColumnLayout {
+                    required property var modelData
+                    spacing: 4
+                    MD.Text {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: modelData.label
+                        typescale: MD.Token.typescale.label_small
+                    }
+                    Item {
+                        Layout.alignment: Qt.AlignHCenter
+                        width: 40
+                        height: 40
+                        Text {
+                            anchors.centerIn: parent
+                            font.family: MD.Token.font.icon_family
+                            font.pixelSize: 24
+                            text: modelData.name
+                            color: MD.MProp.color.on_surface
+                            lineHeight: font.pixelSize
+                            lineHeightMode: Text.FixedHeight
+                        }
+                    }
+                }
+            }
+        }
+
+        MD.Text {
+            text: "Raw MD.Icon sizes 18 / 20 / 24"
+            typescale: MD.Token.typescale.label_large
+        }
+
+        GridLayout {
+            columns: root.artifactIcons.length + 1
+            columnSpacing: 16
+            rowSpacing: 8
+
+            MD.Text {
+                text: ""
+            }
+            Repeater {
+                model: root.artifactIcons
+                delegate: MD.Text {
+                    required property var modelData
+                    text: modelData.label
+                    typescale: MD.Token.typescale.label_small
+                    Layout.alignment: Qt.AlignHCenter
+                }
+            }
+
+            Repeater {
+                model: root.iconSizes
+                delegate: RowLayout {
+                    required property int modelData
+                    readonly property int size: modelData
+
+                    MD.Text {
+                        text: size + "px"
+                        typescale: MD.Token.typescale.label_small
+                    }
+                    Repeater {
+                        model: root.artifactIcons
+                        delegate: MD.Icon {
+                            required property var modelData
+                            Layout.alignment: Qt.AlignHCenter
+                            name: modelData.name
+                            size: parent.size
+                            color: MD.MProp.color.on_surface
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue: #30 

What was fixed:
- Removed `Text.CurveRendering` from `MD.Icon`
- Removed 4× supersampling (`cal_curve_scale` + `Item.scale` on DPR &lt; 2)
- Set `font.pixelSize` to `root.size` (no downscale after oversized rasterization)
- Set `lineHeight` to `font.pixelSize` instead of `label_large.line_height` (20 vs icon size 24)
- Removed unused `lineHeight` property on `Icon`
- Added `tests/scenes/icon_artifacts.qml` for visual repro (IconButton vs FAB-style `Text`)
