### PR TITLE
fix MD.Icon rendering: added bidirectional counter-scale

### DIFF
--- a/qml/component/extra/Icon.qml
+++ b/qml/component/extra/Icon.qml
@@ -34,9 +34,22 @@ Item {
         return v;
     }
 
+    readonly property real _parentScale: {
+        var s = 1.0;
+        for (var p = root.parent; p; p = p.parent)
+            s *= p.scale;
+        return s;
+    }
+    readonly property real _renderScale: {
+        if (MD.Util.epsilonEqual(_parentScale, 1.0))
+            return 1.0;
+        return _parentScale;
+    }
+
     Text {
         id: m_text_icon
         anchors.centerIn: parent
+        transformOrigin: Item.Center
 
         font.family: root.fill ? MD.Token.font.icon_fill_family : MD.Token.font.icon_family
         font.weight: root.weight
@@ -48,7 +61,8 @@ Item {
                 "FILL": root._fillSeg
             };
         }
-        font.pixelSize: root.size
+        font.pixelSize: Math.max(1, Math.round(root.size * root._renderScale))
+        scale: 1.0 / root._renderScale
 
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter

--- a/tests/control_layout.cpp
+++ b/tests/control_layout.cpp
@@ -1641,6 +1641,90 @@ private Q_SLOTS:
         QVERIFY(text->property("renderType").toInt() != curveRenderingType(m_engine));
     }
 
+    void iconCompensatesParentScale() {
+        const auto source = QByteArrayLiteral(R"(
+            import QtQuick
+            import Qcm.Material as MD
+
+            Item {
+                id: host
+                scale: 2
+
+                MD.Icon {
+                    id: icon
+                    name: MD.Token.icon.content_copy
+                    size: 20
+                }
+            }
+        )");
+
+        QQmlComponent component(&m_engine);
+        component.setData(source, QUrl(QStringLiteral("qrc:/tests/icon-parent-scale.qml")));
+        QVERIFY2(! component.isError(), qPrintable(component.errorString()));
+
+        std::unique_ptr<QObject> object(component.create());
+        QVERIFY2(object, qPrintable(component.errorString()));
+        auto* host = qobject_cast<QQuickItem*>(object.get());
+        QVERIFY(host);
+        host->setParentItem(m_window.contentItem());
+        settle(host);
+
+        auto* icon = itemWithIcon(host);
+        QVERIFY(icon);
+        QCOMPARE(icon->property("size").toInt(), 20);
+        QCOMPARE(icon->property("_parentScale").toReal(), 2.0);
+        QCOMPARE(icon->property("_renderScale").toReal(), 2.0);
+
+        auto* text = innerTextItem(icon);
+        QVERIFY(text);
+        const auto font = qvariant_cast<QFont>(text->property("font"));
+        QCOMPARE(font.pixelSize(), 40);
+        QCOMPARE(text->property("lineHeight").toReal(), qreal(font.pixelSize()));
+        QCOMPARE(text->scale(), 0.5);
+    }
+
+    void iconCompensatesParentScaleZoomOut() {
+        const auto source = QByteArrayLiteral(R"(
+            import QtQuick
+            import Qcm.Material as MD
+
+            Item {
+                id: host
+                scale: 0.5
+
+                MD.Icon {
+                    id: icon
+                    name: MD.Token.icon.content_copy
+                    size: 20
+                }
+            }
+        )");
+
+        QQmlComponent component(&m_engine);
+        component.setData(source, QUrl(QStringLiteral("qrc:/tests/icon-parent-scale-zoom-out.qml")));
+        QVERIFY2(! component.isError(), qPrintable(component.errorString()));
+
+        std::unique_ptr<QObject> object(component.create());
+        QVERIFY2(object, qPrintable(component.errorString()));
+        auto* host = qobject_cast<QQuickItem*>(object.get());
+        QVERIFY(host);
+        host->setParentItem(m_window.contentItem());
+        settle(host);
+
+        auto* icon = itemWithIcon(host);
+        QVERIFY(icon);
+        QCOMPARE(icon->property("size").toInt(), 20);
+        QCOMPARE(icon->property("_parentScale").toReal(), 0.5);
+        QCOMPARE(icon->property("_renderScale").toReal(), 0.5);
+
+        auto* text = innerTextItem(icon);
+        QVERIFY(text);
+        const auto font = qvariant_cast<QFont>(text->property("font"));
+        QCOMPARE(font.pixelSize(), 10);
+        QCOMPARE(text->property("lineHeight").toReal(), qreal(font.pixelSize()));
+        QCOMPARE(text->scale(), 2.0);
+    }
+
     void iconButtonContentIconSize() {
         const auto source = QByteArrayLiteral(R"(
             import QtQuick

--- a/tests/scenes/icon_artifacts.qml
+++ b/tests/scenes/icon_artifacts.qml
@@ -9,7 +9,7 @@ import Qcm.Material as MD
 Rectangle {
     id: root
     width: 560
-    height: 420
+    height: 700
     color: MD.Token.color.surface
 
     readonly property var artifactIcons: [
@@ -18,6 +18,7 @@ Rectangle {
         { label: "videocam", name: MD.Token.icon.videocam }
     ]
     readonly property var iconSizes: [18, 20, 24]
+    readonly property var parentScales: [0.3, 0.5, 1.5, 2, 3]
 
     ColumnLayout {
         anchors.fill: parent
@@ -125,6 +126,62 @@ Rectangle {
                             name: modelData.name
                             size: parent.size
                             color: MD.MProp.color.on_surface
+                        }
+                    }
+                }
+            }
+        }
+
+        MD.Text {
+            text: "MD.Icon under scaled parent 0.3×–3× (zoom out + zoom in, size 20)"
+            typescale: MD.Token.typescale.label_large
+        }
+
+        GridLayout {
+            columns: root.artifactIcons.length + 1
+            columnSpacing: 16
+            rowSpacing: 8
+
+            MD.Text {
+                text: ""
+            }
+            Repeater {
+                model: root.artifactIcons
+                delegate: MD.Text {
+                    required property var modelData
+                    text: modelData.label
+                    typescale: MD.Token.typescale.label_small
+                    Layout.alignment: Qt.AlignHCenter
+                }
+            }
+
+            Repeater {
+                model: root.parentScales
+                delegate: RowLayout {
+                    required property real modelData
+                    readonly property real parentScale: modelData
+
+                    MD.Text {
+                        text: parentScale + "×"
+                        typescale: MD.Token.typescale.label_small
+                    }
+                    Repeater {
+                        model: root.artifactIcons
+                        delegate: Item {
+                            required property var modelData
+                            readonly property real rowScale: parent.parent.parentScale
+                            Layout.alignment: Qt.AlignHCenter
+                            width: 20 * rowScale
+                            height: 20 * rowScale
+                            scale: rowScale
+                            transformOrigin: Item.Center
+
+                            MD.Icon {
+                                anchors.centerIn: parent
+                                name: modelData.name
+                                size: 20
+                                color: MD.MProp.color.on_surface
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
fix MD.Icon rendering: added bidirectional counter-scale 
References: #30 #31 