### PR TITLE
The placeholderText scaling mechanism has been changed to eliminate r…

### DIFF
--- a/qml/component/TextField.qml
+++ b/qml/component/TextField.qml
@@ -17,7 +17,7 @@ MD.TextFieldEmbed {
 
     font.capitalization: Font.MixedCase
     typescale: control.mdState.typescale
-    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset, Math.max(contentWidth, m_placeholder.implicitWidth) + leftPadding + rightPadding)
+    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset, Math.max(contentWidth, m_placeholder.restImplicitWidth) + leftPadding + rightPadding)
     implicitHeight: mdState.containerHeight
 
     // If we're clipped, set topInset to half the height of the placeholder text to avoid it being clipped.
@@ -50,7 +50,7 @@ MD.TextFieldEmbed {
         x: control.leftPadding
         width: control.width - (control.leftPadding + control.rightPadding)
         text: control.placeholderText
-        font: control.font
+        sourceFont: control.font
         color: control.mdState.placeholderColor
         opacity: control.mdState.placeholderOpacity
         elide: Text.ElideRight
@@ -113,7 +113,7 @@ MD.TextFieldEmbed {
             MD.OutlineTextFieldShape {
                 borderColor: control.mdState.outlineColor
                 radius: MD.Token.shape.corner.extra_small
-                floatWidth: m_placeholder.implicitWidth * m_placeholder.targetScale + 8
+                floatWidth: m_placeholder.implicitWidth + 8
                 floatX: m_placeholder.x - 4
                 open: m_placeholder.text.length > 0 && m_placeholder.floated
             }

--- a/qml/component/textfield/FloatingPlaceholderText.qml
+++ b/qml/component/textfield/FloatingPlaceholderText.qml
@@ -6,36 +6,45 @@ Text {
     property bool controlHasText: false
     property int verticalPadding: 8
     property int controlHeight: height
-    property int largestHeight: 0
     property color cutoutColor: "transparent"
+    property font sourceFont
 
     property bool filled: false
     property real targetScale: 0.8
     readonly property bool floated: controlFocus || controlHasText
-    y: (controlHeight - height) / 2.0
-    scale: 1.0
+    readonly property int restPixelSize: sourceFont.pixelSize
+    readonly property int floatedPixelSize: Math.round(restPixelSize * targetScale)
+    readonly property int largestHeight: restMetrics.height
+    readonly property real restImplicitWidth: restMetrics.width
+
+    font.family: sourceFont.family
+    font.styleName: sourceFont.styleName
+    font.weight: sourceFont.weight
+    font.letterSpacing: sourceFont.letterSpacing
+    font.capitalization: sourceFont.capitalization
+    font.hintingPreference: sourceFont.hintingPreference
+    font.pixelSize: floated ? floatedPixelSize : restPixelSize
+    y: Math.round((controlHeight - height) / 2.0)
     verticalAlignment: Text.AlignVCenter
+
+    TextMetrics {
+        id: restMetrics
+        text: root.text
+        font.family: root.sourceFont.family
+        font.weight: root.sourceFont.weight
+        font.letterSpacing: root.sourceFont.letterSpacing
+        font.capitalization: root.sourceFont.capitalization
+        font.pixelSize: root.restPixelSize
+    }
 
     Rectangle {
         z: -1
         visible: root.floated && root.cutoutColor.a > 0
         x: -6
         anchors.verticalCenter: parent.verticalCenter
-        width: parent.implicitWidth * parent.scale + 12
-        height: Math.max(2, parent.largestHeight * parent.scale)
+        width: parent.implicitWidth + 12
+        height: Math.max(2, parent.height)
         color: root.cutoutColor
-    }
-
-    transformOrigin: {
-        switch (effectiveHorizontalAlignment) {
-        case Text.AlignLeft:
-        case Text.AlignJustify:
-            return Item.Left;
-        case Text.AlignRight:
-            return Item.Right;
-        case Text.AlignHCenter:
-            return Item.Center;
-        }
     }
 
     states: [
@@ -43,8 +52,8 @@ Text {
             name: 'float'
             when: root.controlFocus || root.controlHasText
             PropertyChanges {
-                root.y: root.filled ? root.verticalPadding : -root.largestHeight / 2.0
-                root.scale: root.targetScale
+                root.y: root.filled ? root.verticalPadding : -Math.round(root.largestHeight
+                                                                         * root.targetScale / 2.0)
             }
         }
     ]
@@ -52,34 +61,17 @@ Text {
     transitions: [
         Transition {
             to: ''
-            ParallelAnimation {
-                YAnimator {
-                    duration: 300
-                    easing.type: Easing.OutSine
-                }
-                ScaleAnimator {
-                    duration: 300
-                    easing.type: Easing.OutSine
-                }
+            YAnimator {
+                duration: 300
+                easing.type: Easing.OutSine
             }
         },
         Transition {
             to: 'float'
-            ParallelAnimation {
-                YAnimator {
-                    duration: 300
-                    easing.type: Easing.OutSine
-                }
-                ScaleAnimator {
-                    duration: 300
-                    easing.type: Easing.OutSine
-                }
+            YAnimator {
+                duration: 300
+                easing.type: Easing.OutSine
             }
         }
     ]
-
-    Component.onCompleted: {
-        largestHeight = implicitHeight;
-        effectiveHorizontalAlignmentChanged();
-    }
 }

--- a/tests/control_layout.cpp
+++ b/tests/control_layout.cpp
@@ -1174,7 +1174,10 @@ private Q_SLOTS:
         auto* placeholder = itemWithText(textField, QStringLiteral("Label"));
         QVERIFY(placeholder);
         const auto placeholderFont = qvariant_cast<QFont>(placeholder->property("font"));
-        QCOMPARE(placeholderFont.pixelSize(), expectedSize);
+        const int  restPixelSize   = placeholder->property("restPixelSize").toInt();
+        QCOMPARE(restPixelSize, expectedSize);
+        QCOMPARE(placeholderFont.pixelSize(),
+                 qRound(restPixelSize * placeholder->property("targetScale").toReal()));
     }
 
     void textFieldSizes_data() {


### PR DESCRIPTION
## Summary

Stops `MD.TextField` floating labels from looking blurry (“pixelated”) when they shrink on focus/input.

- **Root cause:** floated label used `Item.scale` + `ScaleAnimator`, so glyphs were bitmap-scaled
- **Fix:** change `font.pixelSize` between rest and floated sizes; keep only `YAnimator` for the float motion
- **Wiring:** `sourceFont` + `TextMetrics` (`restImplicitWidth` / `largestHeight`) so layout and outline notch stay correct without multiplying by `scale`

## Problem

Material floating labels shrink to ~80% when the field is focused or has text. Scaling the `Text` item visually reduced size but also scaled the rasterized glyphs, which looked soft/blocky on desktop (especially HiDPI / fractional DPR).

## Visual comparison

<!-- Replace the placeholders with uploaded screenshots (or paste GitHub image URLs). -->
<!-- Suggested: same field, same DPR, floated label — crop tightly on the label glyphs. -->

| Before (`Item.scale`) | After (`font.pixelSize`) |
|---|---|
| <img width="526" height="99" alt="Screenshot from 2026-09-04 10-33-38" src="https://github.com/user-attachments/assets/8e2a9da2-4f48-4a85-81fe-84c0ea52b8c6" />| <img width="568" height="94" alt="Screenshot from 2026-09-04 11-20-44" src="https://github.com/user-attachments/assets/d556a89e-b285-4b7e-885f-56a3167c03b2" /> |
| <img width="531" height="82" alt="Screenshot from 2026-09-04 10-34-09" src="https://github.com/user-attachments/assets/753c937b-401f-454c-b7b6-066a49594003" />|  <img width="568" height="94" alt="Screenshot from 2026-09-04 11-20-20" src="https://github.com/user-attachments/assets/c490866f-0565-403e-8819-329bcf5e4474" />|

## Changes

| File | Change |
|------|--------|
| `qml/component/textfield/FloatingPlaceholderText.qml` | `sourceFont`, `restPixelSize` / `floatedPixelSize`, `TextMetrics`; drop `scale` / `ScaleAnimator` / `transformOrigin` |
| `qml/component/TextField.qml` | `sourceFont: control.font`; `restImplicitWidth` for implicit width; `floatWidth` uses post-float `implicitWidth` |
| `tests/control_layout.cpp` | `textFieldTypography` asserts rest size + floated `pixelSize` (`qRound(rest * targetScale)`) |

## Review focus

- Floated label is crisp at `floatedPixelSize` (no `scale`)
- Rest state still uses full `body_large` (or control) size via `sourceFont`
- Outlined notch width tracks floated text without `* targetScale`
- Filled cutout rectangle sizes from real text metrics, not `scale`
- Float transition: Y only, 300ms `OutSine` (size snaps with state; no animated font size)

## Test plan

- [ ] `qm_example` → Components → Text fields: outlined + filled — focus / type / clear — label rises without blur
- [ ] Compare floated label next to body text / icons — edges look sharp on the same DPR
- [ ] Outlined + `leadingIcon` — notch still clears the floated label
- [ ] Filled — cutout still covers the floated label
- [ ] `ctest -R control_layout --output-on-failure` (or full CI) — `textFieldTypography` green
- [ ] `cmake --build . --target qml_material qm_example` — green

## Known limitations / follow-up

Non-blocking for merge:

1. Font size is not interpolated during the float animation (only Y moves); a cross-fade or animated `pixelSize` would be a separate polish pass
2. `targetScale` remains a literal `0.8` (M3-ish), not a design token
3. No visual / screenshot regression test for glyph sharpness
