### PR TITLE
fix: use WordWrap for PlainToolTip and RichToolTip

### DIFF
--- a/qml/component/extra/RichToolTip.qml
+++ b/qml/component/extra/RichToolTip.qml
@@ -91,7 +91,7 @@ T.ToolTip {
             text: control.subhead
             typescale: control.subheadTypescale
             color: control.mdState.textColor
-            wrapMode: Text.Wrap
+            wrapMode: Text.WordWrap
             elide: Text.ElideNone
         }
 
@@ -103,7 +103,7 @@ T.ToolTip {
             text: control.text
             typescale: control.typescale
             color: control.mdState.supportTextColor
-            wrapMode: Text.Wrap
+            wrapMode: Text.WordWrap
             elide: Text.ElideNone
         }
 

--- a/qml/control/PlainToolTip.qml
+++ b/qml/control/PlainToolTip.qml
@@ -77,7 +77,7 @@ T.ToolTip {
         color: control.mdState.textColor
         verticalAlignment: Text.AlignVCenter
         horizontalAlignment: Text.AlignHCenter
-        wrapMode: Text.Wrap
+        wrapMode: Text.WordWrap
     }
 
     background: MD.ElevationRectangle {


### PR DESCRIPTION
These small changes improve the readability of tooltips, as words are no longer separated by line breaks.