### PR TITLE
Added a floating label for the ComboBox, similar to the TextField

### DIFF
--- a/example/Components.qml
+++ b/example/Components.qml
@@ -248,7 +248,7 @@ MD.Page {
                             MD.SplitButton {
                                 text: 'Disabled'
                                 mdState.type: MD.Enum.BtFilled
-                                enabled:false
+                                enabled: false
                                 menu: MD.Menu {
                                     MD.MenuItem {
                                         text: 'Action 1'
@@ -258,7 +258,6 @@ MD.Page {
                                     }
                                 }
                             }
-
                         }
                     }
 
@@ -884,6 +883,13 @@ MD.Page {
                                 mdState.size: MD.Enum.XL
                             }
                         }
+                        MD.ComboBox {
+                            Layout.alignment: Qt.AlignHCenter
+                            Layout.preferredWidth: 200
+                            label: "Size"
+                            editable: true
+                            model: ["Small", "Medium", "Large"]
+                        }
                     }
 
                     ComponentCard {
@@ -1088,7 +1094,6 @@ MD.Page {
                             }
                         }
                     }
-
                 }
             }
             MD.Pane {

--- a/qml/control/ComboBox.qml
+++ b/qml/control/ComboBox.qml
@@ -8,6 +8,7 @@ T.ComboBox {
 
     property int type: MD.Enum.TextFieldOutlined
     property real popupMaximumHeight: 0
+    property string label
     property MD.StateComboBox mdState: MD.StateComboBox {
         item: control
     }
@@ -15,7 +16,16 @@ T.ComboBox {
     implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset, implicitContentWidth + leftPadding + rightPadding)
     implicitHeight: mdState.containerHeight
 
-    topInset: 0
+    font.capitalization: Font.MixedCase
+    Binding {
+        when: control.mdState.typescale
+        control.font.pixelSize: control.mdState.typescale.size
+        control.font.weight: control.mdState.typescale.weight
+        control.font.letterSpacing: control.mdState.typescale.tracking
+        restoreMode: Binding.RestoreNone
+    }
+
+    topInset: clip ? m_label.largestHeight / 2 : 0
     bottomInset: 0
     leftInset: 0
     rightInset: 0
@@ -61,6 +71,25 @@ T.ComboBox {
         verticalAlignment: TextInput.AlignVCenter
     }
 
+    MD.FloatingPlaceholderText {
+        id: m_label
+        x: control.leftPadding
+        width: control.width - (control.leftPadding + control.rightPadding)
+        text: control.label
+        sourceFont: control.font
+        color: control.mdState.labelColor
+        opacity: control.mdState.labelOpacity
+        elide: Text.ElideRight
+
+        controlFocus: control.activeFocus
+        controlHeight: control.height
+        verticalPadding: 0
+
+        filled: false
+        controlHasText: (control.editable ? control.editText : control.displayText).length > 0
+        cutoutColor: "transparent"
+    }
+
     background: Item {
         implicitWidth: 64
         implicitHeight: control.mdState.containerHeight
@@ -68,6 +97,9 @@ T.ComboBox {
             anchors.fill: parent
             borderColor: control.mdState.outlineColor
             radius: MD.Token.shape.corner.extra_small
+            floatWidth: m_label.implicitWidth + 8
+            floatX: m_label.x - 4
+            open: m_label.text.length > 0 && m_label.floated
         }
     }
 

--- a/qml/state/StateComboBox.qml
+++ b/qml/state/StateComboBox.qml
@@ -36,6 +36,8 @@ MD.MState {
     backgroundColor: "transparent"
     supportTextColor: root.ctx.color.on_surface_variant
     outlineColor: root.ctx.color.outline
+    property color labelColor: root.ctx.color.on_surface_variant
+    property real labelOpacity: 1.0
 
     state: {
         if (!item.enabled) return "disabled";
@@ -51,6 +53,8 @@ MD.MState {
             name: "disabled"
             PropertyChanges {
                 root.supportTextColor: root.ctx.color.on_surface
+                root.labelColor: root.ctx.color.on_surface
+                root.labelOpacity: MD.Token.state.disabled_content
                 root.item.contentItem.opacity: 0.38
                 root.item.background.opacity: 0.12
             }
@@ -60,6 +64,7 @@ MD.MState {
             PropertyChanges {
                 root.textColor: root.ctx.color.on_surface
                 root.supportTextColor: root.ctx.color.error
+                root.labelColor: root.ctx.color.error
                 root.outlineColor: root.ctx.color.error
             }
         },
@@ -68,18 +73,21 @@ MD.MState {
             PropertyChanges {
                 root.textColor: root.ctx.color.on_surface
                 root.supportTextColor: root.ctx.color.error
+                root.labelColor: root.ctx.color.on_error_container
                 root.outlineColor: root.ctx.color.on_error_container
             }
         },
         State {
             name: "focus"
             PropertyChanges {
+                root.labelColor: root.ctx.color.primary
                 root.outlineColor: root.ctx.color.primary
             }
         },
         State {
             name: "hovered"
             PropertyChanges {
+                root.labelColor: root.ctx.color.on_surface
                 root.outlineColor: root.ctx.color.on_surface
             }
         }


### PR DESCRIPTION
## Summary
Added a floating label to `ComboBox`, matching the outlined `TextField` contract (`FloatingPlaceholderText`, `topInset` only when `clip`, no changes to shared TextField). Example shows a Combo + TextField stack for a quick visual check.

- Combobox "Menu" reference: https://m3.material.io/components/menus/overview

Named the property `label` instead of `placeholderText`: on Qt `TextField`, `placeholderText` is the empty-field hint; `ComboBox` has no such API, and here the string is a field label (M3), not a “nothing selected yet” placeholder.